### PR TITLE
Spell out the license name more verbosely

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
     <licenses>
         <license>
-            <name>AL 2.0</name>
+            <name>Apache License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>


### PR DESCRIPTION
The current name given to the license in pom.xml is "AL 2.0", which is more difficult to interpret than the more canonical "Apache License, Version 2.0".

Changing the name in the POM file effects the output of the License Maven Plugin (http://mojo.codehaus.org/license-maven-plugin/examples/example-thirdparty.html), making it easier to interpret the output of the add-third-party and aggregate-add-third-party goals.

I would have change the name to "The Apache Software License, Version 2.0", but that form is not found in the license itself.