### PR TITLE
JANDEX-35 Failure to resolve method type variable when using class-level bounded wildcard generics

### DIFF
--- a/src/test/java/org/jboss/jandex/test/BoundedWildcardTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BoundedWildcardTestCase.java
@@ -1,0 +1,37 @@
+package org.jboss.jandex.test;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.Type;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNotNull;
+
+public class BoundedWildcardTestCase {
+
+  public static class TestSubject<T extends Number> implements Comparable<T> {
+    @Override
+    public int compareTo(T o) {
+      return 0;
+    }
+  }
+
+  @Test
+  public void testIndexer() throws IOException {
+    Indexer indexer = new Indexer();
+    InputStream stream = getClass().getClassLoader().getResourceAsStream(TestSubject.class.getName().replace('.', '/') + ".class");
+    indexer.index(stream);
+    Index index = indexer.complete();
+    verifyMethodTypeVariable(index);
+  }
+
+  private void verifyMethodTypeVariable(Index index) {
+    ClassInfo classInfo = index.getClassByName(DotName.createSimple(TestSubject.class.getName()));
+    assertNotNull(classInfo.method("compareTo", Type.create(DotName.createSimple(Number.class.getName()), Type.Kind.CLASS)));
+  }
+}


### PR DESCRIPTION
https://issues.jboss.org/browse/JANDEX-35
fixes failure to resolve method type variable when using class-level bounded wildcard generics

signature list is now sorted before an attempt to resolve type variables is made; class signatures are processed first