### PR TITLE
[JANDEX-35] Failure to resolve method type variable when using class-level bounded wildcard generics

### DIFF
--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -948,7 +948,16 @@ public final class Indexer {
     }
 
     private void applySignatures() {
-        for (int i = 0; i < signatures.size(); i += 2) {
+        int end = signatures.size();
+
+        // Class signature is always the last element and should be processed first
+        Object last = end > 1 ? signatures.get(end - 1) : null;
+        if (last instanceof ClassInfo) {
+            parseClassSignature((String)signatures.get(end - 2), (ClassInfo)last);
+            end -= 2;
+        }
+
+        for (int i = 0; i < end; i += 2) {
             String elementSignature = (String) signatures.get(i);
             Object element = signatures.get(i + 1);
 
@@ -956,8 +965,6 @@ public final class Indexer {
                 parseFieldSignature(elementSignature, (FieldInfo)element);
             } else if (element instanceof MethodInfo) {
                 parseMethodSignature(elementSignature, (MethodInfo) element);
-            } else if (element instanceof ClassInfo) {
-                parseClassSignature(elementSignature, (ClassInfo) element);
             }
         }
     }

--- a/src/test/java/org/jboss/jandex/test/BoundedWildcardTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BoundedWildcardTestCase.java
@@ -1,0 +1,37 @@
+package org.jboss.jandex.test;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.Type;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.Assert.assertNotNull;
+
+public class BoundedWildcardTestCase {
+
+  public static class TestSubject<T extends Number> implements Comparable<T> {
+    @Override
+    public int compareTo(T o) {
+      return 0;
+    }
+  }
+
+  @Test
+  public void testIndexer() throws IOException {
+    Indexer indexer = new Indexer();
+    InputStream stream = getClass().getClassLoader().getResourceAsStream(TestSubject.class.getName().replace('.', '/') + ".class");
+    indexer.index(stream);
+    Index index = indexer.complete();
+    verifyMethodTypeVariable(index);
+  }
+
+  private void verifyMethodTypeVariable(Index index) {
+    ClassInfo classInfo = index.getClassByName(DotName.createSimple(TestSubject.class.getName()));
+    assertNotNull(classInfo.method("compareTo", Type.create(DotName.createSimple(Number.class.getName()), Type.Kind.CLASS)));
+  }
+}


### PR DESCRIPTION
Updated version of #28 that is slightly more efficient