### PR TITLE
Method param names

### DIFF
--- a/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -303,7 +303,7 @@ public final class ClassInfo implements AnnotationTarget {
      * @return the located method or null if not found
      */
     public final MethodInfo method(String name, Type... parameters) {
-        MethodInternal key = new MethodInternal(Utils.toUTF8(name), parameters, null, (short) 0);
+        MethodInternal key = new MethodInternal(Utils.toUTF8(name), MethodInternal.EMPTY_PARAMETER_NAMES, parameters, null, (short) 0);
         int i = Arrays.binarySearch(methods, key, MethodInternal.NAME_AND_PARAMETER_COMPONENT_COMPARATOR);
         return i >= 0 ? new MethodInfo(this, methods[i]) : null;
     }
@@ -318,7 +318,7 @@ public final class ClassInfo implements AnnotationTarget {
      * @return the first discovered method matching this name, or null if no match is found
      */
     public final MethodInfo firstMethod(String name) {
-        MethodInternal key = new MethodInternal(Utils.toUTF8(name), Type.EMPTY_ARRAY, null, (short) 0);
+        MethodInternal key = new MethodInternal(Utils.toUTF8(name), MethodInternal.EMPTY_PARAMETER_NAMES, Type.EMPTY_ARRAY, null, (short) 0);
         int i = Arrays.binarySearch(methods, key, MethodInternal.NAME_AND_PARAMETER_COMPONENT_COMPARATOR);
         if (i < -methods.length) {
             return null;

--- a/src/main/java/org/jboss/jandex/IndexReaderV1.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV1.java
@@ -264,7 +264,7 @@ final class IndexReaderV1 extends IndexReaderImpl {
         short flags = stream.readShort();
 
         byte[] bytes = Utils.toUTF8(name);
-        return new MethodInfo(clazz, bytes, parameters, returnType, flags);
+        return new MethodInfo(clazz, bytes, MethodInternal.EMPTY_PARAMETER_NAMES, parameters, returnType, flags);
     }
 
     private void recordAnnotation(Map<DotName, List<AnnotationInstance>> annotations, DotName annotation, AnnotationInstance instance) {

--- a/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -45,7 +45,7 @@ import java.util.Map;
  */
 final class IndexReaderV2 extends IndexReaderImpl {
     static final int MIN_VERSION = 6;
-    static final int MAX_VERSION = 7;
+    static final int MAX_VERSION = 8;
     static final int MAX_DATA_VERSION = 4;
     private static final byte NULL_TARGET_TAG = 0;
     private static final byte FIELD_TAG = 1;
@@ -456,10 +456,20 @@ final class IndexReaderV2 extends IndexReaderImpl {
                 defaultValue = readAnnotationValue(stream);
             }
         }
+        byte[][] methodParameterBytes = MethodInternal.EMPTY_PARAMETER_NAMES;
+        if (version >= 8) {
+            int size = stream.readPackedU32();
+            if (size > 0 ) {
+                methodParameterBytes = new byte[size][];
+                for (int i = 0; i < size; i++) {
+                    methodParameterBytes[i] = byteTable[stream.readPackedU32()];
+                }
+            }
+        }
 
         MethodInfo methodInfo = new MethodInfo();
         AnnotationInstance[] annotations = readAnnotations(stream, methodInfo);
-        MethodInternal methodInternal = new MethodInternal(name, parameters, returnType, flags,
+        MethodInternal methodInternal = new MethodInternal(name, methodParameterBytes, parameters, returnType, flags,
                 receiverType, typeParameters,
                 exceptions, annotations, defaultValue);
         methodInfo.setMethodInternal(methodInternal);

--- a/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -52,7 +52,7 @@ import java.util.TreeMap;
  */
 final class IndexWriterV2 extends IndexWriterImpl{
     static final int MIN_VERSION = 6;
-    static final int MAX_VERSION = 7;
+    static final int MAX_VERSION = 8;
 
     // babelfish (no h)
     private static final int MAGIC = 0xBABE1F15;
@@ -297,7 +297,13 @@ final class IndexWriterV2 extends IndexWriterImpl{
                 writeAnnotationValue(stream, defaultValue);
             }
         }
-
+        if (version >= 8) {
+            byte[][] parameterNamesBytes = method.parameterNamesBytes();
+            stream.writePackedU32(parameterNamesBytes.length);
+            for (byte[] parameterName : parameterNamesBytes) {
+                stream.writePackedU32(positionOf(parameterName));
+            }
+        }
         AnnotationInstance[] annotations = method.annotationArray();
         stream.writePackedU32(annotations.length);
         for (AnnotationInstance annotation : annotations) {
@@ -733,6 +739,9 @@ final class IndexWriterV2 extends IndexWriterImpl{
         AnnotationValue defaultValue = method.defaultValue();
         if (defaultValue != null) {
             buildAValueEntries(defaultValue);
+        }
+        for (byte[] parameterName : method.parameterNamesBytes()) {
+            names.intern(parameterName);
         }
         names.intern(method.nameBytes());
         names.intern(method);

--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -463,11 +463,19 @@ public final class Indexer {
                 continue;
             byte[] parameterName = nameIndex == 0 ? null : decodeUtf8EntryAsBytes(nameIndex);
             // ignore "this"
-            if(index == 0 && parameterName != null && parameterName.length == 4
+            if(numParameters == 0 && parameterName != null && parameterName.length == 4
                     && parameterName[0] == 0x74
                     && parameterName[1] == 0x68
                     && parameterName[2] == 0x69
                     && parameterName[3] == 0x73)
+                continue;
+            // ignore "this$*" that javac adds (not ECJ)
+            if(numParameters == 0 && parameterName != null && parameterName.length > 5
+                    && parameterName[0] == 0x74
+                    && parameterName[1] == 0x68
+                    && parameterName[2] == 0x69
+                    && parameterName[3] == 0x73
+                    && parameterName[4] == 0x24)
                 continue;
             
             // here we rely on the parameters being in the right order

--- a/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -32,6 +32,7 @@ import java.util.List;
  */
 public final class MethodInfo implements AnnotationTarget {
 
+    static final String[] EMPTY_PARAMETER_NAMES = new String[0];
     private MethodInternal methodInternal;
     private ClassInfo clazz;
 
@@ -44,12 +45,12 @@ public final class MethodInfo implements AnnotationTarget {
         this.clazz = clazz;
     }
 
-    MethodInfo(ClassInfo clazz, byte[] name, Type[] parameters, Type returnType,  short flags) {
-        this(clazz, new MethodInternal(name, parameters, returnType, flags));
+    MethodInfo(ClassInfo clazz, byte[] name, byte[][] parameterNames, Type[] parameters, Type returnType,  short flags) {
+        this(clazz, new MethodInternal(name, parameterNames, parameters, returnType, flags));
     }
 
-    MethodInfo(ClassInfo clazz, byte[] name, Type[] parameters, Type returnType,  short flags, Type[] typeParameters, Type[] exceptions) {
-        this(clazz, new MethodInternal(name, parameters, returnType, flags, typeParameters, exceptions));
+    MethodInfo(ClassInfo clazz, byte[] name, byte[][] parameterNames, Type[] parameters, Type returnType,  short flags, Type[] typeParameters, Type[] exceptions) {
+        this(clazz, new MethodInternal(name, parameterNames, parameters, returnType, flags, typeParameters, exceptions));
     }
 
     /**
@@ -81,6 +82,25 @@ public final class MethodInfo implements AnnotationTarget {
      * @since 2.1
      */
      public static MethodInfo create(ClassInfo clazz, String name, Type[] args, Type returnType, short flags, TypeVariable[] typeParameters, Type[] exceptions) {
+         return create(clazz, name, EMPTY_PARAMETER_NAMES, args, returnType, flags, typeParameters, exceptions);
+     }
+     
+     /**
+      * Construct a new mock Method instance.
+      *
+      * @param clazz the class declaring the field
+      * @param name the name of the field
+      * @param parameterNames the names of the method parameter 
+      * @param args a read only array containing the types of each parameter in parameter order
+      * @param returnType the return value type
+      * @param flags the method attributes
+      * @param typeParameters the generic type parameters for this method
+      * @param exceptions the exceptions declared as thrown by this method
+      * @return a mock method
+      *
+      * @since 2.2
+      */
+     public static MethodInfo create(ClassInfo clazz, String name, String[] parameterNames, Type[] args, Type returnType, short flags, TypeVariable[] typeParameters, Type[] exceptions) {
          if (clazz == null)
              throw new IllegalArgumentException("Clazz can't be null");
 
@@ -88,18 +108,26 @@ public final class MethodInfo implements AnnotationTarget {
              throw new IllegalArgumentException("Name can't be null");
 
          if (args == null)
-            throw new IllegalArgumentException("Values can't be null");
+             throw new IllegalArgumentException("Values can't be null");
+
+         if (parameterNames == null)
+             throw new IllegalArgumentException("Parameter names can't be null");
 
          if (returnType == null)
             throw new IllegalArgumentException("returnType can't be null");
 
          byte[] bytes;
+         byte[][] parameterNameBytes;
          try {
              bytes = name.getBytes("UTF-8");
+             parameterNameBytes = new byte[parameterNames.length][];
+             for (int i = 0; i < parameterNames.length; i++) {
+                parameterNameBytes[i] = parameterNames[i].getBytes("UTF-8");
+            }
          } catch (UnsupportedEncodingException e) {
              throw new IllegalArgumentException(e);
          }
-         return new MethodInfo(clazz, bytes, args, returnType, flags, typeParameters, exceptions);
+         return new MethodInfo(clazz, bytes, parameterNameBytes, args, returnType, flags, typeParameters, exceptions);
      }
 
 
@@ -112,6 +140,15 @@ public final class MethodInfo implements AnnotationTarget {
         return methodInternal.name();
     }
 
+    /**
+     * Returns the name of the given parameter.
+     * @param i the parameter index
+     * @return the name of the given parameter, or null.
+     */
+    public final String parameterName(int i) {
+        return methodInternal.parameterName(i);
+    }
+    
     public final Kind kind() {
         return Kind.METHOD;
     }

--- a/src/main/java/org/jboss/jandex/MethodParameterInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodParameterInfo.java
@@ -67,6 +67,15 @@ public final class MethodParameterInfo implements AnnotationTarget {
     }
 
     /**
+     * Returns the name of this parameter.
+     * 
+     * @return the name of this parameter.
+     */
+    public final String name() {
+        return method.parameterName(parameter);
+    }
+    
+    /**
      * Returns a string representation describing this method parameter
      *
      * @return a string representation of this parameter

--- a/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -303,20 +303,32 @@ public class BasicTestCase {
             
             ClassInfo enumClass = index.getClassByName(DotName.createSimple(Enum.class.getName()));
             assertNotNull(enumClass);
-            // synthetic param counts here
+            // synthetic param counts here (for ECJ)
             MethodInfo enumConstructor1 = enumClass.method("<init>", 
                   Type.create(DotName.createSimple("java.lang.String"), Type.Kind.CLASS), PrimitiveType.INT, PrimitiveType.INT);
-            assertNotNull(enumConstructor1);
-            // synthetic param counts here
-            assertEquals(3, enumConstructor1.parameters().size());
+            if(enumConstructor1 == null) {
+                enumConstructor1 = enumClass.method("<init>", PrimitiveType.INT);
+                assertNotNull(enumConstructor1);
+                // synthetic param does not found here
+                assertEquals(1, enumConstructor1.parameters().size());
+            }else {
+                // synthetic param counts here
+                assertEquals(3, enumConstructor1.parameters().size());
+            }
             // synthetic param does not counts here
             assertEquals("noAnnotation", enumConstructor1.parameterName(0));
 
             MethodInfo enumConstructor2 = enumClass.method("<init>", 
                   Type.create(DotName.createSimple("java.lang.String"), Type.Kind.CLASS), PrimitiveType.INT, PrimitiveType.BYTE);
-            assertNotNull(enumConstructor2);
-            // synthetic param counts here
-            assertEquals(3, enumConstructor2.parameters().size());
+            if(enumConstructor2 == null) {
+                enumConstructor2 = enumClass.method("<init>", PrimitiveType.BYTE);
+                assertNotNull(enumConstructor2);
+                // synthetic param does not found here
+                assertEquals(1, enumConstructor2.parameters().size());
+            }else {
+                // synthetic param counts here
+                assertEquals(3, enumConstructor2.parameters().size());
+            }
             // synthetic param does not counts here
             assertEquals("annotated", enumConstructor2.parameterName(0));
             

--- a/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget.Kind;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -53,6 +54,11 @@ import org.junit.Test;
 public class BasicTestCase {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface FieldAnnotation {
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface ParameterAnnotation {
 
     }
 
@@ -100,8 +106,20 @@ public class BasicTestCase {
         @MethodAnnotation2
         @MethodAnnotation4
         void doSomething(int x, long y, String foo){}
+        
+        public class Nested {
+            public Nested(int noAnnotation) {}
+            public Nested(@ParameterAnnotation byte annotated) {}
+        }
     }
 
+    public enum Enum {
+        A(1), B(2);
+        
+        private Enum(int noAnnotation) {}
+        private Enum(@ParameterAnnotation byte annotated) {}
+    }
+    
     @TestAnnotation(name = "Test", ints = { 1, 2, 3, 4, 5 }, klass = Void.class, nested = @NestedAnnotation(1.34f), nestedArray = {
         @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) }, enums = { ElementType.TYPE, ElementType.PACKAGE }, longValue = 10)
     public static class NestedA implements Serializable {
@@ -128,6 +146,10 @@ public class BasicTestCase {
         indexer.index(stream);
         stream = getClass().getClassLoader().getResourceAsStream(TestAnnotation.class.getName().replace('.', '/') + ".class");
         indexer.index(stream);
+        stream = getClass().getClassLoader().getResourceAsStream(DummyClass.Nested.class.getName().replace('.', '/') + ".class");
+        indexer.index(stream);
+        stream = getClass().getClassLoader().getResourceAsStream(Enum.class.getName().replace('.', '/') + ".class");
+        indexer.index(stream);
         Index index = indexer.complete();
 
         verifyDummy(index, true);
@@ -140,6 +162,10 @@ public class BasicTestCase {
         InputStream stream = getClass().getClassLoader().getResourceAsStream(DummyClass.class.getName().replace('.', '/') + ".class");
         indexer.index(stream);
         stream = getClass().getClassLoader().getResourceAsStream(TestAnnotation.class.getName().replace('.', '/') + ".class");
+        indexer.index(stream);
+        stream = getClass().getClassLoader().getResourceAsStream(DummyClass.Nested.class.getName().replace('.', '/') + ".class");
+        indexer.index(stream);
+        stream = getClass().getClassLoader().getResourceAsStream(Enum.class.getName().replace('.', '/') + ".class");
         indexer.index(stream);
         Index index = indexer.complete();
 
@@ -245,6 +271,60 @@ public class BasicTestCase {
             assertEquals(MethodAnnotation2.class.getName(), method.annotation(DotName.createSimple(MethodAnnotation2.class.getName())).name().toString());
             assertEquals(MethodAnnotation4.class.getName(), method.annotation(DotName.createSimple(MethodAnnotation4.class.getName())).name().toString());
             assertFalse(method.hasAnnotation(DotName.createSimple(MethodAnnotation3.class.getName())));
+            
+            assertEquals("x", method.parameterName(0));
+            assertEquals("y", method.parameterName(1));
+            assertEquals("foo", method.parameterName(2));
+            
+            ClassInfo nested = index.getClassByName(DotName.createSimple(DummyClass.Nested.class.getName()));
+            assertNotNull(nested);
+            // synthetic param counts here
+            MethodInfo nestedConstructor1 = nested.method("<init>", 
+                  Type.create(DotName.createSimple(DummyClass.class.getName()), Type.Kind.CLASS), PrimitiveType.INT);
+            assertNotNull(nestedConstructor1);
+            // synthetic param counts here
+            assertEquals(2, nestedConstructor1.parameters().size());
+            // synthetic param does not counts here
+            assertEquals("noAnnotation", nestedConstructor1.parameterName(0));
+
+            MethodInfo nestedConstructor2 = nested.method("<init>", 
+                  Type.create(DotName.createSimple(DummyClass.class.getName()), Type.Kind.CLASS), PrimitiveType.BYTE);
+            assertNotNull(nestedConstructor2);
+            // synthetic param counts here
+            assertEquals(2, nestedConstructor2.parameters().size());
+            // synthetic param does not counts here
+            assertEquals("annotated", nestedConstructor2.parameterName(0));
+            
+            AnnotationInstance paramAnnotation = nestedConstructor2.annotation(DotName.createSimple(ParameterAnnotation.class.getName()));
+            assertNotNull(paramAnnotation);
+            assertEquals(Kind.METHOD_PARAMETER, paramAnnotation.target().kind());
+            assertEquals("annotated", paramAnnotation.target().asMethodParameter().name());
+            assertEquals(0, paramAnnotation.target().asMethodParameter().position());
+            
+            ClassInfo enumClass = index.getClassByName(DotName.createSimple(Enum.class.getName()));
+            assertNotNull(enumClass);
+            // synthetic param counts here
+            MethodInfo enumConstructor1 = enumClass.method("<init>", 
+                  Type.create(DotName.createSimple("java.lang.String"), Type.Kind.CLASS), PrimitiveType.INT, PrimitiveType.INT);
+            assertNotNull(enumConstructor1);
+            // synthetic param counts here
+            assertEquals(3, enumConstructor1.parameters().size());
+            // synthetic param does not counts here
+            assertEquals("noAnnotation", enumConstructor1.parameterName(0));
+
+            MethodInfo enumConstructor2 = enumClass.method("<init>", 
+                  Type.create(DotName.createSimple("java.lang.String"), Type.Kind.CLASS), PrimitiveType.INT, PrimitiveType.BYTE);
+            assertNotNull(enumConstructor2);
+            // synthetic param counts here
+            assertEquals(3, enumConstructor2.parameters().size());
+            // synthetic param does not counts here
+            assertEquals("annotated", enumConstructor2.parameterName(0));
+            
+            paramAnnotation = enumConstructor2.annotation(DotName.createSimple(ParameterAnnotation.class.getName()));
+            assertNotNull(paramAnnotation);
+            assertEquals(Kind.METHOD_PARAMETER, paramAnnotation.target().kind());
+            assertEquals("annotated", paramAnnotation.target().asMethodParameter().name());
+            assertEquals(0, paramAnnotation.target().asMethodParameter().position());
         }
 
         // Verify hasNoArgsConstructor


### PR DESCRIPTION
Support method parameter names:

- Bumped index version
- Read method param name attribute
- Default to debug info if missing
- Align method param name indices to method param annotation indices (not types)

This is pretty much required for RESTEasy extensions indexed by MP-OpenAPI