### PR TITLE
Synthetic param types

### DIFF
--- a/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -590,6 +590,8 @@ final class IndexReaderV2 extends IndexReaderImpl {
                 ((MethodInfo)target).setClassInfo(clazz);
             } else if (target instanceof FieldInfo) {
                 ((FieldInfo)target).setClassInfo(clazz);
+            } else if (target instanceof MethodParameterInfo) {
+                ((MethodParameterInfo)target).method().setClassInfo(clazz);
             }
         }
     }

--- a/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -141,14 +141,46 @@ public final class MethodInfo implements AnnotationTarget {
     }
 
     /**
-     * Returns the name of the given parameter.
+     * Returns the name of the given parameter, omitting synthetic parameters.
      * @param i the parameter index
-     * @return the name of the given parameter, or null.
+     * @return the name of the given parameter, omitting synthetic parameters, or null.
      */
     public final String parameterName(int i) {
         return methodInternal.parameterName(i);
     }
+
+    /**
+     * Returns the type of the given parameter, omitting synthetic parameters. This
+     * does not support local classes.
+     * @param i the parameter index
+     * @return the type of the given parameter, omitting synthetic parameters, or null.
+     * @throws UnsupportedOperationException if this method's container class is a local class or an enum.
+     */
+    public Type realParameter(int parameter) {
+        parameter += syntheticParameterCount();
+        List<Type> parameters = parameters();
+        return parameters.size() > parameter && parameter >= 0 ? parameters.get(parameter) : null;
+    }
+
+    public int syntheticParameterCount() {
+        if(isStaticClassMember())
+            return 0;
+        return 1;
+    }
     
+    private boolean isStaticClassMember() {
+        switch(declaringClass().nestingType()) {
+        case INNER:
+            return Modifier.isStatic(declaringClass().flags());
+        case ANONYMOUS:
+        case LOCAL:
+            throw new UnsupportedOperationException("Anonymous and local types are not supported");
+        case TOP_LEVEL:
+            return true;
+        }
+        return true;
+    }
+
     public final Kind kind() {
         return Kind.METHOD;
     }

--- a/src/main/java/org/jboss/jandex/MethodParameterInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodParameterInfo.java
@@ -74,7 +74,17 @@ public final class MethodParameterInfo implements AnnotationTarget {
     public final String name() {
         return method.parameterName(parameter);
     }
-    
+
+    /**
+     * Returns the type of this parameter.
+     * 
+     * @return the type of this parameter.
+     * @throws UnsupportedOperationException if this method's container class is a local class or an enum.
+     */
+    public Type type() {
+        return method.realParameter(parameter);
+    }
+
     /**
      * Returns a string representation describing this method parameter
      *


### PR DESCRIPTION
Support a reliable way to get a parameter type for #45

This throws if you try it on a local/anonymous type, but that's OK because you will never care about these constructors since you can't call them with anything useful.