### PR TITLE
Set Automatic-Module-Name and fix maven-enforcer-plugin problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,15 @@
     </licenses>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -88,6 +97,9 @@
                         <manifest>
                             <mainClass>org.jboss.jandex.Main</mainClass>
                         </manifest>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.jboss.jandex</Automatic-Module-Name>
+                        </manifestEntries>
                     </archive>
                     <instructions>
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>


### PR DESCRIPTION
This PR bumps the version of the maven-enforcer-plugin so that it can cope with the version strings of modern JDKs and won't exit with an `ExceptionInInitializerError` when invoked.  It also sets an `Automatic-Module-Name` in the `META-INF/MANIFEST.MF` file.  I followed the module naming guidelines referenced by Stephen Coleburne here: https://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html

This is obviously a stopgap measure until this library can be truly modularized but it at least "claims" the module name with no compatibility issues.

Signed-off-by: Laird Nelson <ljnelson@gmail.com>