### PR TITLE
Add type interface specialization for MethodInfo and FieldInfo

### DIFF
--- a/src/main/java/org/jboss/jandex/ContainingAnnotationTarget.java
+++ b/src/main/java/org/jboss/jandex/ContainingAnnotationTarget.java
@@ -1,0 +1,16 @@
+package org.jboss.jandex;
+
+import java.util.List;
+
+/**
+ * Holds methods common {@link org.jboss.jandex.FieldInfo} and {@link org.jboss.jandex.MethodInfo}.
+ *
+ */
+public interface ContainingAnnotationTarget extends AnnotationTarget {
+
+    List<AnnotationInstance> annotations();
+
+    AnnotationInstance annotation(DotName name);
+
+    boolean hasAnnotation(DotName name);
+}

--- a/src/main/java/org/jboss/jandex/FieldInfo.java
+++ b/src/main/java/org/jboss/jandex/FieldInfo.java
@@ -34,7 +34,7 @@ import java.util.List;
  * @author Jason T. Greene
  *
  */
-public final class FieldInfo implements AnnotationTarget {
+public final class FieldInfo implements ContainingAnnotationTarget {
     private ClassInfo clazz;
     private FieldInternal internal;
 
@@ -107,6 +107,7 @@ public final class FieldInfo implements AnnotationTarget {
      *
      * @return the list of annotations on this field
      */
+    @Override
     public List<AnnotationInstance> annotations() {
         return internal.annotations();
     }
@@ -118,6 +119,7 @@ public final class FieldInfo implements AnnotationTarget {
      * @param name the name of the annotation to locate on this field
      * @return the annotation if found, otherwise, null
      */
+    @Override
     public final AnnotationInstance annotation(DotName name) {
         return  internal.annotation(name);
     }
@@ -130,6 +132,7 @@ public final class FieldInfo implements AnnotationTarget {
      * @param name the name of the annotation to look for
      * @return true if the annotation is present, false otherwise
      */
+    @Override
     public final boolean hasAnnotation(DotName name) {
         return internal.hasAnnotation(name);
     }

--- a/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -30,7 +30,7 @@ import java.util.List;
  *
  * @author Jason T. Greene
  */
-public final class MethodInfo implements AnnotationTarget {
+public final class MethodInfo implements ContainingAnnotationTarget {
 
     static final String[] EMPTY_PARAMETER_NAMES = new String[0];
     private MethodInternal methodInternal;
@@ -254,6 +254,7 @@ public final class MethodInfo implements AnnotationTarget {
      *
      * @return the annotation instances declared on this class or its parameters, or an empty list if none
      */
+    @Override
     public final List<AnnotationInstance> annotations() {
         return methodInternal.annotations();
     }
@@ -281,6 +282,7 @@ public final class MethodInfo implements AnnotationTarget {
      * @param name the name of the annotation to locate within the method
      * @return the annotation if found, otherwise, null
      */
+    @Override
     public final AnnotationInstance annotation(DotName name) {
         return  methodInternal.annotation(name);
     }
@@ -294,6 +296,7 @@ public final class MethodInfo implements AnnotationTarget {
      * @param name the name of the annotation to look for
      * @return true if the annotation is present, false otherwise
      */
+    @Override
     public final boolean hasAnnotation(DotName name) {
         return methodInternal.hasAnnotation(name);
     }


### PR DESCRIPTION
This can be useful when iterating over annotations of methods and fields
for example when one wants to collect and/or manipulate the list of
annotations that class "properties" have