### PR TITLE
Fix snippet which does not compile nor work

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,9 @@ The following example demonstrates indexing the Thread and String classes, and s
 Indexer indexer = new Indexer();
 InputStream stream = getClass().getClassLoader()
                                .getResourceAsStream("java/lang/Thread.class");
-InputStream stream = getClass().getClassLoader()
-                               .getResourceAsStream("java/lang/String.class");
+indexer.index(stream);
+stream = getClass().getClassLoader()
+                   .getResourceAsStream("java/lang/String.class");
 indexer.index(stream);
 Index index = indexer.complete();
 DotName deprecated = DotName.createSimple("java.lang.Deprecated");


### PR DESCRIPTION
due to `Duplicate local variable stream` and missed call to `index()`