### PR TITLE
Store original member positions for unsorted iteration

### DIFF
--- a/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -53,7 +53,7 @@ public final class ClassInfo implements AnnotationTarget {
     private static final byte[] EMPTY_POSITIONS = new byte[0];
 
     private final DotName name;
-    private final Map<DotName, List<AnnotationInstance>> annotations;
+    private Map<DotName, List<AnnotationInstance>> annotations;
 
     // Not final to allow lazy initialization, immutable once published
     private short flags;
@@ -159,16 +159,15 @@ public final class ClassInfo implements AnnotationTarget {
 
     }
 
-    ClassInfo(DotName name, Type superClassType, short flags, Type[] interfaceTypes, Map<DotName, List<AnnotationInstance>> annotations) {
-        this(name, superClassType, flags, interfaceTypes, annotations, false);
+    ClassInfo(DotName name, Type superClassType, short flags, Type[] interfaceTypes) {
+        this(name, superClassType, flags, interfaceTypes, false);
     }
 
-    ClassInfo(DotName name, Type superClassType, short flags, Type[] interfaceTypes, Map<DotName, List<AnnotationInstance>> annotations, boolean hasNoArgsConstructor) {
+    ClassInfo(DotName name, Type superClassType, short flags, Type[] interfaceTypes, boolean hasNoArgsConstructor) {
         this.name = name;
         this.superClassType = superClassType;
         this.flags = flags;
         this.interfaceTypes = interfaceTypes.length == 0 ? Type.EMPTY_ARRAY : interfaceTypes;
-        this.annotations = Collections.unmodifiableMap(annotations);  // FIXME
         this.hasNoArgsConstructor = hasNoArgsConstructor;
         this.typeParameters = Type.EMPTY_ARRAY;
         this.methods = MethodInternal.EMPTY_ARRAY;
@@ -195,7 +194,9 @@ public final class ClassInfo implements AnnotationTarget {
         }
 
         ClassType superClassType = superName == null ? null : new ClassType(superName);
-        return new ClassInfo(name, superClassType, flags, interfaceTypes, annotations, hasNoArgsConstructor);
+        ClassInfo clazz = new ClassInfo(name, superClassType, flags, interfaceTypes, hasNoArgsConstructor);
+        clazz.setAnnotations(annotations);
+        return clazz;
     }
 
     @Override
@@ -288,7 +289,11 @@ public final class ClassInfo implements AnnotationTarget {
      * @return the annotations specified on this class and its elements
      */
     public final Map<DotName, List<AnnotationInstance>> annotations() {
-        return annotations;
+        return Collections.unmodifiableMap(annotations);
+    }
+
+    final void setAnnotations(Map<DotName, List<AnnotationInstance>> annotations) {
+        this.annotations = annotations;
     }
 
     /**

--- a/src/main/java/org/jboss/jandex/FieldInfoGenerator.java
+++ b/src/main/java/org/jboss/jandex/FieldInfoGenerator.java
@@ -19,7 +19,6 @@ package org.jboss.jandex;
 
 import java.util.AbstractList;
 
-
 /**
  * A list which wraps FieldInternal objects with a FieldInfo, so that
  * the declaring class' reference can be set. This lazy construction
@@ -30,15 +29,18 @@ import java.util.AbstractList;
 class FieldInfoGenerator extends AbstractList<FieldInfo> {
     private final FieldInternal[] fields;
     private final ClassInfo clazz;
+    private final byte[] positions;
 
-    public FieldInfoGenerator(ClassInfo clazz, FieldInternal[] fields) {
+    public FieldInfoGenerator(ClassInfo clazz, FieldInternal[] fields, byte[] positions) {
         this.clazz = clazz;
         this.fields = fields;
+        this.positions = positions;
     }
 
     @Override
     public FieldInfo get(int i) {
-        return new FieldInfo(clazz, fields[i]);
+        FieldInternal field = (positions.length > 0) ? fields[positions[i] & 0xFF] : fields[i];
+        return new FieldInfo(clazz, field);
     }
 
     @Override

--- a/src/main/java/org/jboss/jandex/IndexReaderV1.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV1.java
@@ -18,9 +18,7 @@
 
 package org.jboss.jandex;
 
-import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -129,13 +127,14 @@ final class IndexReaderV1 extends IndexReaderImpl {
 
             Map<DotName, List<AnnotationInstance>> annotations = new HashMap<DotName, List<AnnotationInstance>>();
             Type superClassType = superName == null ? null : new ClassType(superName);
-            ClassInfo clazz = new ClassInfo(name, superClassType, flags, interfaceTypes, annotations, hasNoArgsConstructor);
+            ClassInfo clazz = new ClassInfo(name, superClassType, flags, interfaceTypes, hasNoArgsConstructor);
             classes.put(name, clazz);
             addClassToMap(subclasses, superName, clazz);
             for (Type interfaceName : interfaces) {
                 addClassToMap(implementors, interfaceName.name(), clazz);
             }
             readAnnotations(stream, annotations, clazz);
+            clazz.setAnnotations(annotations);
         }
 
         return Index.create(masterAnnotations, subclasses, implementors, classes);

--- a/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -535,22 +535,14 @@ final class IndexReaderV2 extends IndexReaderImpl {
         clazz.setFieldArray(fields);
 
         if (version >= 10) {
-            byte[] positions = new byte[stream.readPackedU32()];
-            for (int i = 0; i < positions.length; i++) {
-                positions[i] = (byte) stream.readPackedU32();
-            }
-            clazz.setFieldPositionArray(positions);
+            clazz.setFieldPositionArray(byteTable[stream.readPackedU32()]);
         }
 
         MethodInternal[] methods = readClassMethods(stream, clazz);
         clazz.setMethodArray(methods);
 
         if (version >= 10) {
-            byte[] positions = new byte[stream.readPackedU32()];
-            for (int i = 0; i < positions.length; i++) {
-                positions[i] = (byte) stream.readPackedU32();
-            }
-            clazz.setMethodPositionArray(positions);
+            clazz.setMethodPositionArray(byteTable[stream.readPackedU32()]);
         }
 
         for (int i = 0; i < size; i++) {

--- a/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -45,7 +45,7 @@ import java.util.Map;
  */
 final class IndexReaderV2 extends IndexReaderImpl {
     static final int MIN_VERSION = 6;
-    static final int MAX_VERSION = 9;
+    static final int MAX_VERSION = 10;
     static final int MAX_DATA_VERSION = 4;
     private static final byte NULL_TARGET_TAG = 0;
     private static final byte FIELD_TAG = 1;
@@ -534,8 +534,24 @@ final class IndexReaderV2 extends IndexReaderImpl {
         FieldInternal[] fields = readClassFields(stream, clazz);
         clazz.setFieldArray(fields);
 
+        if (version >= 10) {
+            byte[] positions = new byte[stream.readPackedU32()];
+            for (int i = 0; i < positions.length; i++) {
+                positions[i] = (byte) stream.readPackedU32();
+            }
+            clazz.setFieldPositionArray(positions);
+        }
+
         MethodInternal[] methods = readClassMethods(stream, clazz);
         clazz.setMethodArray(methods);
+
+        if (version >= 10) {
+            byte[] positions = new byte[stream.readPackedU32()];
+            for (int i = 0; i < positions.length; i++) {
+                positions[i] = (byte) stream.readPackedU32();
+            }
+            clazz.setMethodPositionArray(positions);
+        }
 
         for (int i = 0; i < size; i++) {
             List<AnnotationInstance> instances = convertToList(readAnnotations(stream, clazz));

--- a/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -216,7 +216,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
 
     private AnnotationValue[] readAnnotationValues(PackedDataInputStream stream) throws IOException {
         int numValues = stream.readPackedU32();
-        AnnotationValue[] values = new AnnotationValue[numValues];
+        AnnotationValue[] values = numValues > 0 ? new AnnotationValue[numValues] : AnnotationValue.EMPTY_VALUE_ARRAY;
 
         for (int i = 0; i < numValues; i++) {
             AnnotationValue value = readAnnotationValue(stream);
@@ -520,8 +520,10 @@ final class IndexReaderV2 extends IndexReaderImpl {
 
         int size = stream.readPackedU32();
 
-        Map<DotName, List<AnnotationInstance>> annotations = new HashMap<DotName, List<AnnotationInstance>>(size);
-        ClassInfo clazz = new ClassInfo(name, superType, flags, interfaceTypes, annotations);
+        Map<DotName, List<AnnotationInstance>> annotations = size > 0
+                ? new HashMap<DotName, List<AnnotationInstance>>(size)
+                : Collections.<DotName, List<AnnotationInstance>>emptyMap();
+        ClassInfo clazz = new ClassInfo(name, superType, flags, interfaceTypes);
         clazz.setTypeParameters(typeParameters);
 
         if (hasNesting) {
@@ -554,7 +556,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
             }
         }
 
-
+        clazz.setAnnotations(annotations);
 
         return clazz;
     }
@@ -590,7 +592,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
 
     private FieldInternal[] readClassFields(PackedDataInputStream stream, ClassInfo clazz) throws IOException {
         int len = stream.readPackedU32();
-        FieldInternal[] fields = new FieldInternal[len];
+        FieldInternal[] fields = len > 0 ? new FieldInternal[len] : FieldInternal.EMPTY_ARRAY;
         for (int i = 0; i < len; i++) {
             FieldInternal field = fieldTable[stream.readPackedU32()];
             updateAnnotationTargetInfo(field.annotationArray(), clazz);
@@ -601,7 +603,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
 
     private MethodInternal[] readClassMethods(PackedDataInputStream stream, ClassInfo clazz) throws IOException {
         int len = stream.readPackedU32();
-        MethodInternal[] methods = new MethodInternal[len];
+        MethodInternal[] methods = len > 0 ? new MethodInternal[len] : MethodInternal.EMPTY_ARRAY;
         for (int i = 0; i < len; i++) {
             MethodInternal method = methodTable[stream.readPackedU32()];
             updateAnnotationTargetInfo(method.annotationArray(), clazz);

--- a/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -525,7 +525,7 @@ final class IndexWriterV2 extends IndexWriterImpl{
         }
 
         if (version >= 10) {
-            writePositions(stream, clazz.fieldPositionArray());
+            stream.writePackedU32(positionOf(clazz.fieldPositionArray()));
         }
 
         MethodInternal[] methods = clazz.methodArray();
@@ -535,7 +535,7 @@ final class IndexWriterV2 extends IndexWriterImpl{
         }
 
         if (version >= 10) {
-            writePositions(stream, clazz.methodPositionArray());
+            stream.writePackedU32(positionOf(clazz.methodPositionArray()));
         }
 
         Set<Entry<DotName, List<AnnotationInstance>>> entrySet = clazz.annotations().entrySet();
@@ -545,13 +545,6 @@ final class IndexWriterV2 extends IndexWriterImpl{
             for (AnnotationInstance annotation : value) {
                 writeReferenceOrFull(stream, annotation);
             }
-        }
-    }
-
-    private void writePositions(PackedDataOutputStream stream, byte[] positions) throws IOException {
-        stream.writePackedU32(positions.length);
-        for (byte position : positions) {
-            stream.writePackedU32(position & 0xFF);
         }
     }
 
@@ -720,8 +713,12 @@ final class IndexWriterV2 extends IndexWriterImpl{
             addString(name);
         }
         addEnclosingMethod(clazz.enclosingMethod());
+
         addMethodList(clazz.methodArray());
+        names.intern(clazz.methodPositionArray());
+
         addFieldList(clazz.fieldArray());
+        names.intern(clazz.fieldPositionArray());
 
         for (Entry<DotName, List<AnnotationInstance>> entry :  clazz.annotations().entrySet()) {
             addClassName(entry.getKey());

--- a/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -52,7 +52,7 @@ import java.util.TreeMap;
  */
 final class IndexWriterV2 extends IndexWriterImpl{
     static final int MIN_VERSION = 6;
-    static final int MAX_VERSION = 9;
+    static final int MAX_VERSION = 10;
 
     // babelfish (no h)
     private static final int MAGIC = 0xBABE1F15;
@@ -524,10 +524,18 @@ final class IndexWriterV2 extends IndexWriterImpl{
             stream.writePackedU32(positionOf(field));
         }
 
+        if (version >= 10) {
+            writePositions(stream, clazz.fieldPositionArray());
+        }
+
         MethodInternal[] methods = clazz.methodArray();
         stream.writePackedU32(methods.length);
         for (MethodInternal method : methods) {
             stream.writePackedU32(positionOf(method));
+        }
+
+        if (version >= 10) {
+            writePositions(stream, clazz.methodPositionArray());
         }
 
         Set<Entry<DotName, List<AnnotationInstance>>> entrySet = clazz.annotations().entrySet();
@@ -537,6 +545,13 @@ final class IndexWriterV2 extends IndexWriterImpl{
             for (AnnotationInstance annotation : value) {
                 writeReferenceOrFull(stream, annotation);
             }
+        }
+    }
+
+    private void writePositions(PackedDataOutputStream stream, byte[] positions) throws IOException {
+        stream.writePackedU32(positions.length);
+        for (byte position : positions) {
+            stream.writePackedU32(position & 0xFF);
         }
     }
 

--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -138,17 +138,17 @@ public final class Indexer {
     private final static byte[] METHOD_PARAMETERS = new byte[] {
         0x4d, 0x65, 0x74, 0x68, 0x6f, 0x64, 0x50, 0x61, 0x72, 0x61, 0x6d, 0x65, 0x74, 0x65, 0x72, 0x73
     };
-    
+
     // "LocalVariableTable"
     private final static byte[] LOCAL_VARIABLE_TABLE = new byte[] {
         0x4c, 0x6f, 0x63, 0x61, 0x6c, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x54, 0x61, 0x62, 0x6c, 0x65
     };
-    
+
     // "Code"
     private final static byte[] CODE = new byte[] {
         0x43, 0x6f, 0x64, 0x65
     };
-    
+
     private final static int RUNTIME_ANNOTATIONS_LEN = RUNTIME_ANNOTATIONS.length;
     private final static int RUNTIME_PARAM_ANNOTATIONS_LEN = RUNTIME_PARAM_ANNOTATIONS.length;
     private final static int RUNTIME_TYPE_ANNOTATIONS_LEN = RUNTIME_TYPE_ANNOTATIONS.length;
@@ -305,7 +305,7 @@ public final class Indexer {
             processAttributes(data, method);
             method.setAnnotations(elementAnnotations);
             elementAnnotations.clear();
-            
+
             // Prefer method parameter names over debug info
             if(methodParameterNames != null)
                 method.methodInternal().setParameterNames(methodParameterNames);
@@ -440,7 +440,7 @@ public final class Indexer {
 
             parameterNames[filledParameters++] = parameterName;
         }
-        
+
         byte[][] realParameterNames = filledParameters > 0 ? new byte[filledParameters][] : MethodInternal.EMPTY_PARAMETER_NAMES;
         if(filledParameters > 0)
             System.arraycopy(parameterNames, 0, realParameterNames, 0, filledParameters);
@@ -457,7 +457,7 @@ public final class Indexer {
             int nameIndex = data.readUnsignedShort();
             int descriptorIndex = data.readUnsignedShort();
             int index = data.readUnsignedShort();
-            
+
             // parameters have startPc == 0
             if(startPc != 0)
                 continue;
@@ -477,7 +477,7 @@ public final class Indexer {
                     && parameterName[3] == 0x73
                     && parameterName[4] == 0x24)
                 continue;
-            
+
             // here we rely on the parameters being in the right order
             variableNames[numParameters++] = parameterName;
         }
@@ -1336,7 +1336,7 @@ public final class Indexer {
         Type superClassType = superName == null ? null : intern(new ClassType(superName));
 
         this.classAnnotations = new HashMap<DotName, List<AnnotationInstance>>();
-        this.currentClass = new ClassInfo(thisName, superClassType, flags, interfaceTypes, classAnnotations);
+        this.currentClass = new ClassInfo(thisName, superClassType, flags, interfaceTypes);
 
         if (superName != null)
             addSubclass(superName, currentClass);
@@ -1699,6 +1699,7 @@ public final class Indexer {
 
             currentClass.setMethods(methods, names);
             currentClass.setFields(fields, names);
+            currentClass.setAnnotations(classAnnotations);
 
             return currentClass;
         } catch (IgnoreModuleInfoException e) {

--- a/src/main/java/org/jboss/jandex/MethodInfoGenerator.java
+++ b/src/main/java/org/jboss/jandex/MethodInfoGenerator.java
@@ -29,15 +29,18 @@ import java.util.AbstractList;
 class MethodInfoGenerator extends AbstractList<MethodInfo> {
     private final MethodInternal[] methods;
     private final ClassInfo clazz;
+    private final byte[] positions;
 
-    public MethodInfoGenerator(ClassInfo clazz, MethodInternal[] methods) {
+    public MethodInfoGenerator(ClassInfo clazz, MethodInternal[] methods, byte[] positions) {
         this.clazz = clazz;
         this.methods = methods;
+        this.positions = positions;
     }
 
     @Override
     public MethodInfo get(int i) {
-        return new MethodInfo(clazz, methods[i]);
+        MethodInternal method = (positions.length > 0) ? methods[positions[i] & 0xFF] : methods[i];
+        return new MethodInfo(clazz, method);
     }
 
     @Override

--- a/src/test/java/org/jboss/jandex/test/ClassInfoMemberPositionTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/ClassInfoMemberPositionTestCase.java
@@ -1,0 +1,679 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.jandex.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ClassInfoMemberPositionTestCase {
+
+    private Index index;
+
+    @Before
+    public void setUp() throws IOException {
+        Indexer indexer = new Indexer();
+        String prefix = "org/jboss/jandex/test/ClassInfoMemberPositionTestCase$";
+        indexer.index(getClass().getClassLoader().getResourceAsStream(prefix + "TestEntity.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream(prefix + "MaxSizeTestEntity.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream(prefix + "OverMaxSizeTestEntity.class"));
+        this.index = indexer.complete();
+    }
+
+    @Test
+    public void testMembersUnsorted() {
+        assertOriginalPositions(index);
+    }
+
+    @Test
+    public void testMembersUnsortedWithFile() throws IOException {
+        File tmpIndex = File.createTempFile("cls", ".idx");
+        OutputStream output = null;
+        try {
+            output = new FileOutputStream(tmpIndex);
+            IndexWriter writer = new IndexWriter(output);
+            writer.write(this.index);
+        } finally {
+            if (output != null) {
+                output.close();
+            }
+        }
+
+        InputStream input = null;
+        Index fileIndex;
+        try {
+            input = new FileInputStream(tmpIndex);
+            IndexReader reader = new IndexReader(input);
+            fileIndex = reader.read();
+        } finally {
+            if (input != null) {
+                input.close();
+            }
+        }
+
+        assertOriginalPositions(fileIndex);
+    }
+
+    @Test
+    public void testMaxMembersUnsortedAndSorted() {
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(MaxSizeTestEntity.class.getName()));
+        assertNotNull(clazz);
+
+        List<FieldInfo> unsortedFields = clazz.unsortedFields();
+        for (int i = 0; i < 256; i++) {
+            assertEquals(String.format("f%03d", 255 - i), unsortedFields.get(i).name());
+        }
+
+        List<FieldInfo> sortedFields = clazz.fields();
+        for (int i = 0; i < 256; i++) {
+            assertEquals(String.format("f%03d", i), sortedFields.get(i).name());
+        }
+    }
+
+    @Test
+    public void testOverMaxMembersUnsortedAndSorted() {
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(OverMaxSizeTestEntity.class.getName()));
+        assertNotNull(clazz);
+
+        List<FieldInfo> unsortedFields = clazz.unsortedFields();
+        for (int i = 0; i < 257; i++) {
+            assertEquals(String.format("f%03d", i), unsortedFields.get(i).name());
+        }
+
+        List<FieldInfo> sortedFields = clazz.fields();
+        for (int i = 0; i < 257; i++) {
+            assertEquals(String.format("f%03d", i), sortedFields.get(i).name());
+        }
+    }
+
+    private static void assertOriginalPositions(Index index) {
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(TestEntity.class.getName()));
+        assertNotNull(clazz);
+
+        List<FieldInfo> fields = clazz.unsortedFields();
+        int f = 0;
+        assertEquals("z", fields.get(f++).name());
+        assertEquals("omega", fields.get(f++).name());
+        assertEquals("y", fields.get(f++).name());
+        assertEquals("x", fields.get(f++).name());
+        assertEquals("alpha", fields.get(f++).name());
+
+        List<MethodInfo> methods = clazz.unsortedMethods();
+        int m = 0;
+        assertEquals("c", methods.get(m++).name());
+        assertEquals("<init>", methods.get(m++).name());
+        assertEquals("a", methods.get(m++).name());
+        assertEquals("<init>", methods.get(m++).name());
+        assertEquals("b", methods.get(m++).name());
+        assertEquals("_", methods.get(m++).name());
+    }
+
+    static class TestEntity {
+        String z;
+        static int omega;
+        void c() {};
+        String y;
+        String x;
+        public TestEntity() {
+        }
+        void a() {};
+        public TestEntity(String optional) {
+        }
+        void b() {};
+        static long alpha;
+
+        void _() {};
+    }
+
+    static class MaxSizeTestEntity {
+        int f255;
+        int f254;
+        int f253;
+        int f252;
+        int f251;
+        int f250;
+        int f249;
+        int f248;
+        int f247;
+        int f246;
+        int f245;
+        int f244;
+        int f243;
+        int f242;
+        int f241;
+        int f240;
+        int f239;
+        int f238;
+        int f237;
+        int f236;
+        int f235;
+        int f234;
+        int f233;
+        int f232;
+        int f231;
+        int f230;
+        int f229;
+        int f228;
+        int f227;
+        int f226;
+        int f225;
+        int f224;
+        int f223;
+        int f222;
+        int f221;
+        int f220;
+        int f219;
+        int f218;
+        int f217;
+        int f216;
+        int f215;
+        int f214;
+        int f213;
+        int f212;
+        int f211;
+        int f210;
+        int f209;
+        int f208;
+        int f207;
+        int f206;
+        int f205;
+        int f204;
+        int f203;
+        int f202;
+        int f201;
+        int f200;
+        int f199;
+        int f198;
+        int f197;
+        int f196;
+        int f195;
+        int f194;
+        int f193;
+        int f192;
+        int f191;
+        int f190;
+        int f189;
+        int f188;
+        int f187;
+        int f186;
+        int f185;
+        int f184;
+        int f183;
+        int f182;
+        int f181;
+        int f180;
+        int f179;
+        int f178;
+        int f177;
+        int f176;
+        int f175;
+        int f174;
+        int f173;
+        int f172;
+        int f171;
+        int f170;
+        int f169;
+        int f168;
+        int f167;
+        int f166;
+        int f165;
+        int f164;
+        int f163;
+        int f162;
+        int f161;
+        int f160;
+        int f159;
+        int f158;
+        int f157;
+        int f156;
+        int f155;
+        int f154;
+        int f153;
+        int f152;
+        int f151;
+        int f150;
+        int f149;
+        int f148;
+        int f147;
+        int f146;
+        int f145;
+        int f144;
+        int f143;
+        int f142;
+        int f141;
+        int f140;
+        int f139;
+        int f138;
+        int f137;
+        int f136;
+        int f135;
+        int f134;
+        int f133;
+        int f132;
+        int f131;
+        int f130;
+        int f129;
+        int f128;
+        int f127;
+        int f126;
+        int f125;
+        int f124;
+        int f123;
+        int f122;
+        int f121;
+        int f120;
+        int f119;
+        int f118;
+        int f117;
+        int f116;
+        int f115;
+        int f114;
+        int f113;
+        int f112;
+        int f111;
+        int f110;
+        int f109;
+        int f108;
+        int f107;
+        int f106;
+        int f105;
+        int f104;
+        int f103;
+        int f102;
+        int f101;
+        int f100;
+        int f099;
+        int f098;
+        int f097;
+        int f096;
+        int f095;
+        int f094;
+        int f093;
+        int f092;
+        int f091;
+        int f090;
+        int f089;
+        int f088;
+        int f087;
+        int f086;
+        int f085;
+        int f084;
+        int f083;
+        int f082;
+        int f081;
+        int f080;
+        int f079;
+        int f078;
+        int f077;
+        int f076;
+        int f075;
+        int f074;
+        int f073;
+        int f072;
+        int f071;
+        int f070;
+        int f069;
+        int f068;
+        int f067;
+        int f066;
+        int f065;
+        int f064;
+        int f063;
+        int f062;
+        int f061;
+        int f060;
+        int f059;
+        int f058;
+        int f057;
+        int f056;
+        int f055;
+        int f054;
+        int f053;
+        int f052;
+        int f051;
+        int f050;
+        int f049;
+        int f048;
+        int f047;
+        int f046;
+        int f045;
+        int f044;
+        int f043;
+        int f042;
+        int f041;
+        int f040;
+        int f039;
+        int f038;
+        int f037;
+        int f036;
+        int f035;
+        int f034;
+        int f033;
+        int f032;
+        int f031;
+        int f030;
+        int f029;
+        int f028;
+        int f027;
+        int f026;
+        int f025;
+        int f024;
+        int f023;
+        int f022;
+        int f021;
+        int f020;
+        int f019;
+        int f018;
+        int f017;
+        int f016;
+        int f015;
+        int f014;
+        int f013;
+        int f012;
+        int f011;
+        int f010;
+        int f009;
+        int f008;
+        int f007;
+        int f006;
+        int f005;
+        int f004;
+        int f003;
+        int f002;
+        int f001;
+        int f000;
+    }
+
+    static class OverMaxSizeTestEntity {
+        int f256;
+        int f255;
+        int f254;
+        int f253;
+        int f252;
+        int f251;
+        int f250;
+        int f249;
+        int f248;
+        int f247;
+        int f246;
+        int f245;
+        int f244;
+        int f243;
+        int f242;
+        int f241;
+        int f240;
+        int f239;
+        int f238;
+        int f237;
+        int f236;
+        int f235;
+        int f234;
+        int f233;
+        int f232;
+        int f231;
+        int f230;
+        int f229;
+        int f228;
+        int f227;
+        int f226;
+        int f225;
+        int f224;
+        int f223;
+        int f222;
+        int f221;
+        int f220;
+        int f219;
+        int f218;
+        int f217;
+        int f216;
+        int f215;
+        int f214;
+        int f213;
+        int f212;
+        int f211;
+        int f210;
+        int f209;
+        int f208;
+        int f207;
+        int f206;
+        int f205;
+        int f204;
+        int f203;
+        int f202;
+        int f201;
+        int f200;
+        int f199;
+        int f198;
+        int f197;
+        int f196;
+        int f195;
+        int f194;
+        int f193;
+        int f192;
+        int f191;
+        int f190;
+        int f189;
+        int f188;
+        int f187;
+        int f186;
+        int f185;
+        int f184;
+        int f183;
+        int f182;
+        int f181;
+        int f180;
+        int f179;
+        int f178;
+        int f177;
+        int f176;
+        int f175;
+        int f174;
+        int f173;
+        int f172;
+        int f171;
+        int f170;
+        int f169;
+        int f168;
+        int f167;
+        int f166;
+        int f165;
+        int f164;
+        int f163;
+        int f162;
+        int f161;
+        int f160;
+        int f159;
+        int f158;
+        int f157;
+        int f156;
+        int f155;
+        int f154;
+        int f153;
+        int f152;
+        int f151;
+        int f150;
+        int f149;
+        int f148;
+        int f147;
+        int f146;
+        int f145;
+        int f144;
+        int f143;
+        int f142;
+        int f141;
+        int f140;
+        int f139;
+        int f138;
+        int f137;
+        int f136;
+        int f135;
+        int f134;
+        int f133;
+        int f132;
+        int f131;
+        int f130;
+        int f129;
+        int f128;
+        int f127;
+        int f126;
+        int f125;
+        int f124;
+        int f123;
+        int f122;
+        int f121;
+        int f120;
+        int f119;
+        int f118;
+        int f117;
+        int f116;
+        int f115;
+        int f114;
+        int f113;
+        int f112;
+        int f111;
+        int f110;
+        int f109;
+        int f108;
+        int f107;
+        int f106;
+        int f105;
+        int f104;
+        int f103;
+        int f102;
+        int f101;
+        int f100;
+        int f099;
+        int f098;
+        int f097;
+        int f096;
+        int f095;
+        int f094;
+        int f093;
+        int f092;
+        int f091;
+        int f090;
+        int f089;
+        int f088;
+        int f087;
+        int f086;
+        int f085;
+        int f084;
+        int f083;
+        int f082;
+        int f081;
+        int f080;
+        int f079;
+        int f078;
+        int f077;
+        int f076;
+        int f075;
+        int f074;
+        int f073;
+        int f072;
+        int f071;
+        int f070;
+        int f069;
+        int f068;
+        int f067;
+        int f066;
+        int f065;
+        int f064;
+        int f063;
+        int f062;
+        int f061;
+        int f060;
+        int f059;
+        int f058;
+        int f057;
+        int f056;
+        int f055;
+        int f054;
+        int f053;
+        int f052;
+        int f051;
+        int f050;
+        int f049;
+        int f048;
+        int f047;
+        int f046;
+        int f045;
+        int f044;
+        int f043;
+        int f042;
+        int f041;
+        int f040;
+        int f039;
+        int f038;
+        int f037;
+        int f036;
+        int f035;
+        int f034;
+        int f033;
+        int f032;
+        int f031;
+        int f030;
+        int f029;
+        int f028;
+        int f027;
+        int f026;
+        int f025;
+        int f024;
+        int f023;
+        int f022;
+        int f021;
+        int f020;
+        int f019;
+        int f018;
+        int f017;
+        int f016;
+        int f015;
+        int f014;
+        int f013;
+        int f012;
+        int f011;
+        int f010;
+        int f009;
+        int f008;
+        int f007;
+        int f006;
+        int f005;
+        int f004;
+        int f003;
+        int f002;
+        int f001;
+        int f000;
+    }
+}


### PR DESCRIPTION
Fixes #58 
Supersedes #61 

This change supports the storage of class member positions, as originally scanned from the byte stream. The positions are only utilized when client code requests a list of `unsortedFields` or `unsortedMethods`.

Indexing the rt.jar file from JRE 1.8.0_232 produces the following index size:
1. 4,836,637 bytes using release version 2.1.2.Final of Jandex
2. 5,237,838 bytes with the changes in this PR

A very simple test to load the two indexes shows that the version in this PR uses approximately 1,200k more heap memory (28,345,736 `main` thread Bytes) than 2.1.2.Final (27,128,488 `main` thread Bytes)

```java
public class Load {
    public static void main(String[] args) throws Exception {
        IndexReader reader = new IndexReader(new FileInputStream(args[0]));
        Index index = reader.read();
        Thread.sleep(600000L);
    }
}
```