### PR TITLE
Add parameter-related coherent API methods

### DIFF
--- a/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -20,6 +20,9 @@ package org.jboss.jandex;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -188,6 +191,30 @@ public final class MethodInfo implements AnnotationTarget {
     }
 
     /**
+     * Returns a list containing the {@link MethodParameterInfo} instances
+     * describing all parameters declared on this method, in parameter order.
+     * This method may return an empty list, but never null.
+     *
+     * @return a list of {@link MethodParameterInfo} describing all of parameters declared on this method
+     */
+    public final List<MethodParameterInfo> parametersList() {
+
+        final List<Type> paramTypes = methodInternal.parameters();
+
+        if (paramTypes.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        final MethodParameterInfo[] paramArray = new MethodParameterInfo[paramTypes.size()];
+
+        for (short position = 0; position < paramArray.length; position++) {
+            paramArray[position] = new MethodParameterInfo(this, position);
+        }
+
+        return Collections.unmodifiableList(Arrays.asList(paramArray));
+    } 
+
+    /**
      * Returns this method's return parameter type.
      * If this method has a void return, a special void type is returned. This method will never return null.
      *
@@ -252,12 +279,11 @@ public final class MethodInfo implements AnnotationTarget {
      *     public &lt;{@literal @}AnotherTypeAnnotation T&gt; void foo(T t) {...}
      * </pre>
      *
-     * @return the annotation instances declared on this class or its parameters, or an empty list if none
+     * @return the annotation instances declared on this method or its parameters, or an empty list if none
      */
     public final List<AnnotationInstance> annotations() {
         return methodInternal.annotations();
     }
-
 
     /**
      * Retrieves an annotation instance declared on this method, it parameters, or any type within the signature
@@ -296,6 +322,31 @@ public final class MethodInfo implements AnnotationTarget {
      */
     public final boolean hasAnnotation(DotName name) {
         return methodInternal.hasAnnotation(name);
+    }
+
+    /**
+     * Returns the annotation instances declared on this method, without
+     * annotations defined against method parameters.
+     *
+     * @return the annotation instances declared on this method, or an empty list if none
+     */
+    public final List<AnnotationInstance> methodAnnotations() {
+
+        final List<AnnotationInstance> allAnnotations = annotations();
+        final List<AnnotationInstance> methodAnnotations = new ArrayList<AnnotationInstance>();
+
+        for (AnnotationInstance annotation : allAnnotations) {
+            final AnnotationTarget target = annotation.target();
+            if (target.kind() == AnnotationTarget.Kind.METHOD) {
+            	methodAnnotations.add(annotation);
+            }
+        }
+
+        if (methodAnnotations.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return Collections.unmodifiableList(methodAnnotations);
     }
 
     /**

--- a/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -49,8 +50,10 @@ import org.jboss.jandex.IndexReader;
 import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.MethodParameterInfo;
 import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
+import org.junit.Assert;
 import org.junit.Test;
 
 public class BasicTestCase {
@@ -382,22 +385,40 @@ public class BasicTestCase {
             assertNotNull(nestedConstructor1);
             // synthetic param counts here
             assertEquals(2, nestedConstructor1.parameters().size());
+            assertEquals(2, nestedConstructor1.parametersList().size());
             // synthetic param does not counts here
             assertEquals("noAnnotation", nestedConstructor1.parameterName(0));
+
+            List<MethodParameterInfo> nestedInit0ParametersList = nestedConstructor1.parametersList();
+            MethodParameterInfo nestedParamNoAnnotation = nestedInit0ParametersList.get(0);
+            assertEquals("noAnnotation", nestedInit0ParametersList.get(0).name());
+            assertEquals(0, nestedParamNoAnnotation.position());
+            assertEquals(0, nestedParamNoAnnotation.annotations().size());
+            assertNull(nestedParamNoAnnotation.annotation(DotName.createSimple(ParameterAnnotation.class.getName())));
+            assertFalse(nestedParamNoAnnotation.hasAnnotation(DotName.createSimple(ParameterAnnotation.class.getName())));
 
             MethodInfo nestedConstructor2 = nested.method("<init>", 
                   Type.create(DotName.createSimple(DummyClass.class.getName()), Type.Kind.CLASS), PrimitiveType.BYTE);
             assertNotNull(nestedConstructor2);
             // synthetic param counts here
             assertEquals(2, nestedConstructor2.parameters().size());
+            assertEquals(2, nestedConstructor2.parametersList().size());
             // synthetic param does not counts here
             assertEquals("annotated", nestedConstructor2.parameterName(0));
-            
+
             AnnotationInstance paramAnnotation = nestedConstructor2.annotation(DotName.createSimple(ParameterAnnotation.class.getName()));
             assertNotNull(paramAnnotation);
             assertEquals(Kind.METHOD_PARAMETER, paramAnnotation.target().kind());
             assertEquals("annotated", paramAnnotation.target().asMethodParameter().name());
             assertEquals(0, paramAnnotation.target().asMethodParameter().position());
+
+            List<MethodParameterInfo> nestedInit1ParametersList = nestedConstructor2.parametersList();
+            MethodParameterInfo nestedParamAnnotated = nestedInit1ParametersList.get(0);
+            assertEquals("annotated", nestedParamAnnotated.name());
+            assertEquals(0, nestedParamAnnotated.position());
+            assertEquals(1, nestedParamAnnotated.annotations().size());
+            assertNotNull(nestedParamAnnotated.annotation(DotName.createSimple(ParameterAnnotation.class.getName())));
+            assertTrue(nestedParamAnnotated.hasAnnotation(DotName.createSimple(ParameterAnnotation.class.getName())));
             
             ClassInfo enumClass = index.getClassByName(DotName.createSimple(Enum.class.getName()));
             assertNotNull(enumClass);
@@ -409,9 +430,11 @@ public class BasicTestCase {
                 assertNotNull(enumConstructor1);
                 // synthetic param does not found here
                 assertEquals(1, enumConstructor1.parameters().size());
+                assertEquals(1, enumConstructor1.parametersList().size());
             }else {
                 // synthetic param counts here
                 assertEquals(3, enumConstructor1.parameters().size());
+                assertEquals(3, enumConstructor1.parametersList().size());
             }
             // synthetic param does not counts here
             assertEquals("noAnnotation", enumConstructor1.parameterName(0));
@@ -423,9 +446,11 @@ public class BasicTestCase {
                 assertNotNull(enumConstructor2);
                 // synthetic param does not found here
                 assertEquals(1, enumConstructor2.parameters().size());
+                assertEquals(1, enumConstructor2.parametersList().size());
             }else {
                 // synthetic param counts here
                 assertEquals(3, enumConstructor2.parameters().size());
+                assertEquals(3, enumConstructor2.parametersList().size());
             }
             // synthetic param does not counts here
             assertEquals("annotated", enumConstructor2.parameterName(0));


### PR DESCRIPTION
Hello Jandex Team!

Right now Jandex API for `MethodInfo` does not expose `MethodParameterInfo` directly. Some w/a for this limitation is to create custom class which acts the same way as the `MethodParameterInfo`, but why do we have to reinvent the wheel if we can add missing methods directly in Jandex API.

There were some discussions in https://github.com/quarkusio/quarkus/issues/8054 and https://github.com/quarkusio/quarkus/issues/2493 and this PR is to mitigate the root issue, i.e. it is to add missing methods in `MethodInfo` and `MethodParameterInfo` classes and, as the result, make Jandex API more user friendly.

@mkouba This is to address some of the problems we discussed in issues mentioned above.

To summarise. This PR adds the following methods:

* `MethodInfo.parametersList()` - list method parameters (infos not types)
* `MethodInfo.methodAnnotations()` - list method annotations (without param annotations)
* `MethodParameterInfo.annotations()` - list annotations defined on parameter
* `MethodParameterInfo.annotation(DotName)` - get parameter annotation with given name
* `MethodParameterInfo.hasAnnotation(DotName)` - is parameter annotated with given annotation

Unit tests included.

Please let me know in case of any issues.

