### PR TITLE
Repeatable annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,4 +149,17 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <repositories>
+        <repository>
+            <id>jboss-public-repository</id>
+            <name>JBoss Repository</name>
+            <url>https://repository.jboss.org/nexus/content/groups/public</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.jboss.jandex</groupId>
             <artifactId>typeannotation-test</artifactId>
-            <version>1.0</version>
+            <version>1.1</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
@@ -149,41 +149,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
-    <profiles>
-        <profile>
-            <id>jdk18</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-                <jdk>[1.8,)</jdk>
-            </activation>
-            <properties>
-                <maven.compiler.source>1.8</maven.compiler.source>
-                <maven.compiler.target>1.8</maven.compiler.target>
-            </properties>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>add-test-source</id>
-                                <phase>generate-test-sources</phase>
-                                <goals>
-                                    <goal>add-test-source</goal>
-                                </goals>
-                                <configuration>
-                                    <sources>
-                                        <source>src/test/java8</source>
-                                    </sources>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
-    
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -149,4 +149,41 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    
+    <profiles>
+        <profile>
+            <id>jdk18</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+                <jdk>[1.8,)</jdk>
+            </activation>
+            <properties>
+                <maven.compiler.source>1.8</maven.compiler.source>
+                <maven.compiler.target>1.8</maven.compiler.target>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>build-helper-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>add-test-source</id>
+                                <phase>generate-test-sources</phase>
+                                <goals>
+                                    <goal>add-test-source</goal>
+                                </goals>
+                                <configuration>
+                                    <sources>
+                                        <source>src/test/java8</source>
+                                    </sources>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+    
 </project>

--- a/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -73,6 +73,17 @@ public class CompositeIndex implements IndexView {
         }
         return Collections.unmodifiableList(allInstances);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, IndexView index) {
+        List<AnnotationInstance> allInstances = new ArrayList<AnnotationInstance>();
+        for (IndexView i : indexes) {
+            allInstances.addAll(i.getAnnotationsWithRepeatable(annotationName, index));
+        }
+        return Collections.unmodifiableList(allInstances);
+    }
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/jboss/jandex/Index.java
+++ b/src/main/java/org/jboss/jandex/Index.java
@@ -18,7 +18,9 @@
 
 package org.jboss.jandex;
 
+import java.lang.annotation.Repeatable;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -45,6 +47,8 @@ import java.util.Set;
 public final class Index implements IndexView {
     private static final List<AnnotationInstance> EMPTY_ANNOTATION_LIST = Collections.emptyList();
     private static final List<ClassInfo> EMPTY_CLASSINFO_LIST = Collections.emptyList();
+    
+    static final DotName REPEATABLE = DotName.createSimple(Repeatable.class.getName());
 
     final Map<DotName, List<AnnotationInstance>> annotations;
     final Map<DotName, List<ClassInfo>> subclasses;
@@ -75,7 +79,6 @@ public final class Index implements IndexView {
         return new Index(annotations, subclasses, implementors, classes);
     }
 
-
     /**
      * {@inheritDoc}
      */
@@ -83,6 +86,39 @@ public final class Index implements IndexView {
         List<AnnotationInstance> list = annotations.get(annotationName);
         return list == null ? EMPTY_ANNOTATION_LIST: Collections.unmodifiableList(list);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, IndexView index) {
+        ClassInfo annotationClass = index.getClassByName(annotationName);
+        if (annotationClass == null) {
+            throw new IllegalArgumentException("Index does not contain the annotation definition: " + annotationName);
+        }
+        if (!annotationClass.isAnnotation()) {
+            throw new IllegalArgumentException("Not an annotation type: " + annotationClass);
+        }
+        AnnotationInstance repeatable = annotationClass.classAnnotation(REPEATABLE);
+        if (repeatable == null) {
+            // Not a repeatable annotation
+            return getAnnotations(annotationName);
+        }
+        Type containing = repeatable.value().asClass();
+        return getRepeatableAnnotations(annotationName, containing.name());
+    }
+    
+    private Collection<AnnotationInstance> getRepeatableAnnotations(DotName annotationName, DotName containingAnnotationName) {
+        List<AnnotationInstance> instances = new ArrayList<AnnotationInstance>();
+        instances.addAll(getAnnotations(annotationName));
+        for (AnnotationInstance containingInstance : getAnnotations(containingAnnotationName)) {
+            for (AnnotationInstance nestedInstance : containingInstance.value().asNestedArray()) {
+                // We need to set the target of the containing instance
+                instances.add(new AnnotationInstance(nestedInstance.name(), containingInstance.target(), nestedInstance.valueArray()));
+            }
+        }
+        return instances;
+    }
+
 
     /**
      * {@inheritDoc}

--- a/src/main/java/org/jboss/jandex/IndexView.java
+++ b/src/main/java/org/jboss/jandex/IndexView.java
@@ -109,4 +109,16 @@ public interface IndexView {
      * @return a non-null list of annotation instances
      */
     public Collection<AnnotationInstance> getAnnotations(DotName annotationName);
+    
+    /**
+     * Obtains a list of instances for the specified annotation. If the specified annotation is repeatable (JLS 9.6), the result also contains all values from
+     * all instances of the container annotation. In this case, the {@link AnnotationInstance#target()} returns the target of the container annotation instance.
+     * 
+     * @throws IllegalArgumentException If the the defining annotation class is not found
+     * @param annotationName the name of the repeatable annotation
+     * @param index the index containing the annotation class
+     * @return a non-null list of annotation instances
+     * @throws IllegalArgumentException If the index does not contain the annotation definition or if it does not represent an annotation type
+     */
+    public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, IndexView index);
 }

--- a/src/test/java8/org/jboss/jandex/test/RepeatableAnnotationsTestCase.java
+++ b/src/test/java8/org/jboss/jandex/test/RepeatableAnnotationsTestCase.java
@@ -1,0 +1,198 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.jandex.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.AnnotationTarget.Kind;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.junit.Test;
+
+public class RepeatableAnnotationsTestCase {
+
+    static final DotName ALPHA_NAME = DotName.createSimple(Alpha.class.getName());
+    static final DotName ALPHA_CONTAINER_NAME = DotName.createSimple(AlphaContainer.class.getName());
+    static final DotName MY_ANNOTATED_NAME = DotName.createSimple(MyAnnotated.class.getName());
+
+    @Repeatable(AlphaContainer.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Alpha {
+
+        int value();
+
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface AlphaContainer {
+
+        Alpha[] value();
+
+    }
+
+    @Alpha(0)
+    static class MyAnnotated {
+
+        @Alpha(-1)
+        @Alpha(-2)
+        int myField;
+        
+        @Alpha(-3)
+        int anotherField;
+
+        @Alpha(1)
+        public void foo(@Alpha(11) @Alpha(12) String fooName) {
+        }
+
+        @Alpha(2)
+        @Alpha(3)
+        public void bar(@Alpha(10) String barName) {
+        }
+
+    }
+
+    @Test
+    public void testIndexView() throws IOException {
+        Index index = getIndexForClass(MyAnnotated.class, Alpha.class);
+        Collection<AnnotationInstance> instances = index.getAnnotationsWithRepeatable(ALPHA_NAME, index);
+        assertEquals(10, instances.size());
+        assertValues(find(instances, Kind.CLASS, null), 0);
+        assertValues(find(instances, Kind.METHOD, "foo"), 1);
+        assertValues(find(instances, Kind.METHOD_PARAMETER, "fooName"), 11, 12);
+        assertValues(find(instances, Kind.METHOD, "bar"), 2, 3);
+        assertValues(find(instances, Kind.METHOD_PARAMETER, "barName"), 10);
+        // MyAnnotated.myField
+        assertValues(find(instances, Kind.FIELD, "myField"), -1, -2);
+        assertValues(find(instances, Kind.FIELD, "anotherField"), -3);
+    }
+
+    @Test
+    public void testClassInfo() throws IOException {
+        Index index = getIndexForClass(MyAnnotated.class, Alpha.class);
+        ClassInfo alpha = index.getClassByName(MY_ANNOTATED_NAME);
+        assertValues(alpha.classAnnotationsWithRepeatable(ALPHA_NAME, index), 0);
+    }
+
+    @Test
+    public void testMethodInfo() throws IOException {
+        Index index = getIndexForClass(MyAnnotated.class, Alpha.class);
+        ClassInfo alpha = index.getClassByName(MY_ANNOTATED_NAME);
+        // MyAnnotated.foo()
+        MethodInfo foo = alpha.method("foo", Type.create(DotName.createSimple(String.class.getName()), org.jboss.jandex.Type.Kind.CLASS));
+        List<AnnotationInstance> fooInstances = foo.annotationsWithRepeatable(ALPHA_NAME, index);
+        assertEquals(3, fooInstances.size());
+        assertValues(find(fooInstances, Kind.METHOD, null), 1);
+        assertValues(find(fooInstances, Kind.METHOD_PARAMETER, null), 11, 12);
+        // MyAnnotated.bar()
+        MethodInfo bar = alpha.method("bar", Type.create(DotName.createSimple(String.class.getName()), org.jboss.jandex.Type.Kind.CLASS));
+        List<AnnotationInstance> barInstances = bar.annotationsWithRepeatable(ALPHA_NAME, index);
+        assertEquals(3, barInstances.size());
+        List<AnnotationInstance> barMethodInstance = find(barInstances, Kind.METHOD, null);
+        // Test the target of an instance coming from the container
+        assertEquals(bar, barMethodInstance.get(0).target());
+        assertValues(barMethodInstance, 2, 3);
+        assertValues(find(barInstances, Kind.METHOD_PARAMETER, null), 10);
+    }
+
+    @Test
+    public void testFieldInfo() throws IOException {
+        Index index = getIndexForClass(MyAnnotated.class, Alpha.class);
+        ClassInfo alpha = index.getClassByName(MY_ANNOTATED_NAME);
+        FieldInfo myField = alpha.field("myField");
+        assertValues(myField.annotationsWithRepeatable(ALPHA_NAME, index), -1, -2);
+        FieldInfo anotherField = alpha.field("anotherField");
+        assertValues(anotherField.annotationsWithRepeatable(ALPHA_NAME, index), -3);
+        // Test that it's still possible to query the contaier annotation
+        List<AnnotationInstance> direct = myField.annotations();
+        assertEquals(1, direct.size());
+        assertEquals(ALPHA_CONTAINER_NAME, direct.get(0).name());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAnnotationDefinitionNotAvailable() throws IOException {
+        Index index = getIndexForClass(MyAnnotated.class);
+        index.getAnnotationsWithRepeatable(ALPHA_NAME, index);
+
+    }
+
+    private void assertValues(Collection<AnnotationInstance> instances, Integer... values) {
+        assertEquals(values.length, instances.size());
+        List<Integer> list = Arrays.asList(values);
+        for (AnnotationInstance i : instances) {
+            assertTrue(i + " is not found in " + values, list.contains(i.value().asInt()));
+        }
+    }
+
+    private Index getIndexForClass(Class<?>... classes) throws IOException {
+        Indexer indexer = new Indexer();
+        for (Class<?> clazz : classes) {
+            InputStream stream = getClass().getClassLoader().getResourceAsStream(clazz.getName().replace('.', '/') + ".class");
+            indexer.index(stream);
+        }
+        return indexer.complete();
+    }
+
+    private List<AnnotationInstance> find(Collection<AnnotationInstance> instances, AnnotationTarget.Kind kind, String name) {
+        List<AnnotationInstance> ret = new ArrayList<AnnotationInstance>();
+        for (AnnotationInstance instance : instances) {
+            if (instance.target().kind() == kind) {
+                switch (kind) {
+                    case METHOD:
+                        if (name != null && !instance.target().asMethod().name().equals(name)) {
+                            continue;
+                        }
+                        break;
+                    case FIELD:
+                        if (name != null && !instance.target().asField().name().equals(name)) {
+                            continue;
+                        }
+                        break;
+                    case METHOD_PARAMETER:
+                        if (name != null && !instance.target().asMethodParameter().name().equals(name)) {
+                            continue;
+                        }
+                        break;
+                    default:
+                        break;
+                }
+                ret.add(instance);
+            }
+        }
+        return ret;
+    }
+
+}


### PR DESCRIPTION
This is a POC for #67.

I've added several methods, most of them follow the naming and approach of `AnnotationInstance.valueWithDefault()`, i.e. the method declares an `IndexView` param that is used to obtain the annotation type definition and determine the repeatable annotation container (if present).

Note that `MethodInfo.annotationsWithRepeatable()` is a bit special because it should align with the contract of `MethodInfo.annotations()` which returns annotations declared on method or its parameters.

`IndexView.getAnnotationsWithRepeatable()` and `MethodInfo.annotationsWithRepeatable()`  are also special because they need to replace the target of the returned annotation instances for the ones coming from the container, otherwise it wouldn't be possible to determine the exact location of the respective annotation (see `org.jboss.jandex.AnnotationInstance.target()`).

NOTE: `annotationsWithRepeatable()` is not very nice but I did not find a better name that would indicate the meaning...