### PR TITLE
WIP Added class constant indexing for #84

### DIFF
--- a/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -219,5 +219,25 @@ public class CompositeIndex implements IndexView {
         }
         return Collections.unmodifiableCollection(allKnown);
     }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<ClassInfo> getKnownUsers(DotName usedClass) {
+        final List<ClassInfo> users = new ArrayList<ClassInfo>();
+        Set<DotName> processedClasses = new HashSet<DotName>();
+        for (IndexView index : indexes) {
+            final Collection<ClassInfo> set = index.getKnownUsers(usedClass);
+            if (set != null) {
+                for (ClassInfo classInfo : set) {
+                    if(processedClasses.add(classInfo.name())) {
+                        users.add(classInfo);
+                    }
+                }
+            }
+        }
+        return Collections.unmodifiableCollection(users);
+    }
 }
 

--- a/src/main/java/org/jboss/jandex/Index.java
+++ b/src/main/java/org/jboss/jandex/Index.java
@@ -52,13 +52,17 @@ public final class Index implements IndexView {
     final Map<DotName, List<AnnotationInstance>> annotations;
     final Map<DotName, List<ClassInfo>> subclasses;
     final Map<DotName, List<ClassInfo>> implementors;
+    final Map<DotName, List<ClassInfo>> users;
     final Map<DotName, ClassInfo> classes;
 
-    Index(Map<DotName, List<AnnotationInstance>> annotations, Map<DotName, List<ClassInfo>> subclasses, Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes) {
+    Index(Map<DotName, List<AnnotationInstance>> annotations, Map<DotName, List<ClassInfo>> subclasses, 
+          Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes,
+          Map<DotName, List<ClassInfo>> users) {
         this.annotations = Collections.unmodifiableMap(annotations);
         this.classes = Collections.unmodifiableMap(classes);
         this.subclasses = Collections.unmodifiableMap(subclasses);
         this.implementors = Collections.unmodifiableMap(implementors);
+        this.users = Collections.unmodifiableMap(users);
     }
 
 
@@ -74,8 +78,11 @@ public final class Index implements IndexView {
      * @param classes A map to lookup classes by class name
      * @return the index
      */
-    public static Index create(Map<DotName, List<AnnotationInstance>> annotations, Map<DotName, List<ClassInfo>> subclasses, Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes) {
-        return new Index(annotations, subclasses, implementors, classes);
+    public static Index create(Map<DotName, List<AnnotationInstance>> annotations, Map<DotName, List<ClassInfo>> subclasses, 
+                               Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes,
+                               Map<DotName, List<ClassInfo>> users) {
+        // FIXME: API?
+        return new Index(annotations, subclasses, implementors, classes, users);
     }
 
     /**
@@ -270,5 +277,14 @@ public final class Index implements IndexView {
             for (ClassInfo clazz : entry.getValue())
                 System.out.println("    " + clazz.name());
         }
+    }
+
+    @Override
+    public List<ClassInfo> getKnownUsers(DotName usedClass) {
+        List<ClassInfo> ret = users.get(usedClass);
+        if(ret == null) {
+            return EMPTY_CLASSINFO_LIST;
+        }
+        return Collections.unmodifiableList(ret);
     }
 }

--- a/src/main/java/org/jboss/jandex/IndexReaderV1.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV1.java
@@ -22,6 +22,7 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -110,6 +111,7 @@ final class IndexReaderV1 extends IndexReaderImpl {
         HashMap<DotName, List<ClassInfo>> subclasses = new HashMap<DotName, List<ClassInfo>>();
         HashMap<DotName, List<ClassInfo>> implementors = new HashMap<DotName, List<ClassInfo>>();
         HashMap<DotName, ClassInfo> classes = new HashMap<DotName, ClassInfo>();
+        Map<DotName, List<ClassInfo>> users = Collections.emptyMap();
         masterAnnotations = new HashMap<DotName, List<AnnotationInstance>>();
 
         for (int i = 0; i < entries; i++) {
@@ -138,7 +140,7 @@ final class IndexReaderV1 extends IndexReaderImpl {
             readAnnotations(stream, annotations, clazz);
         }
 
-        return Index.create(masterAnnotations, subclasses, implementors, classes);
+        return Index.create(masterAnnotations, subclasses, implementors, classes, users);
     }
 
 

--- a/src/main/java/org/jboss/jandex/IndexView.java
+++ b/src/main/java/org/jboss/jandex/IndexView.java
@@ -121,4 +121,6 @@ public interface IndexView {
      * @throws IllegalArgumentException If the index does not contain the annotation definition or if it does not represent an annotation type
      */
     public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, IndexView index);
+
+    public Collection<ClassInfo> getKnownUsers(DotName usedClass);
 }

--- a/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
@@ -52,7 +53,7 @@ import java.util.TreeMap;
  */
 final class IndexWriterV2 extends IndexWriterImpl{
     static final int MIN_VERSION = 6;
-    static final int MAX_VERSION = 9;
+    static final int MAX_VERSION = 10;
 
     // babelfish (no h)
     private static final int MAGIC = 0xBABE1F15;
@@ -188,9 +189,11 @@ final class IndexWriterV2 extends IndexWriterImpl{
         stream.writePackedU32(index.annotations.size());
         stream.writePackedU32(index.implementors.size());
         stream.writePackedU32(index.subclasses.size());
+        if(version >= 10) {
+            stream.writePackedU32(index.users.size());
+        }
 
-
-        buildTables(index);
+        buildTables(index, version);
         writeByteTable(stream);
         writeStringTable(stream);
         writeNameTable(stream);
@@ -202,12 +205,31 @@ final class IndexWriterV2 extends IndexWriterImpl{
 
         writeTypeTable(stream);
         writeTypeListTable(stream);
+        if(version >= 10) {
+            writeUsersTable(stream, index.users);
+        }
         writeMethodTable(stream, version);
         writeFieldTable(stream);
         writeClasses(stream, index, version);
         stream.flush();
         return stream.size();
     }
+
+    private void writeUsersTable(PackedDataOutputStream stream, Map<DotName, List<ClassInfo>> users) throws IOException {
+        for (Entry<DotName, List<ClassInfo>> entry : users.entrySet()) {
+            writeUsersSet(stream, entry.getKey(), entry.getValue());
+        }
+    }
+
+
+    private void writeUsersSet(PackedDataOutputStream stream, DotName user, List<ClassInfo> uses) throws IOException {
+        stream.writePackedU32(positionOf(user));
+        stream.writePackedU32(uses.size());
+        for (ClassInfo use : uses) {
+            stream.writePackedU32(positionOf(use.name()));
+        }
+    }
+
 
     private void writeStringTable(PackedDataOutputStream stream) throws IOException {
         StrongInternPool<String> stringPool = names.stringPool();
@@ -672,7 +694,7 @@ final class IndexWriterV2 extends IndexWriterImpl{
         }
     }
 
-    private void buildTables(Index index) {
+    private void buildTables(Index index, int version) {
         nameTable = new TreeMap<DotName, Integer>();
         annotationTable = new ReferenceTable<AnnotationInstance>();
         typeTable = new ReferenceTable<Type>();
@@ -682,6 +704,16 @@ final class IndexWriterV2 extends IndexWriterImpl{
         // Build the stringPool for all strings
         for (ClassInfo clazz : index.getKnownClasses()) {
             addClass(clazz);
+        }
+        if (version >= 10) {
+            if (index.users != null) {
+                for (Entry<DotName, List<ClassInfo>> entry : index.users.entrySet()) {
+                    addClassName(entry.getKey());
+                    for (ClassInfo classInfo : entry.getValue()) {
+                        addClassName(classInfo.name());
+                    }
+                }
+            }
         }
     }
 

--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -251,6 +251,7 @@ public final class Indexer {
     private Map<DotName, List<ClassInfo>> subclasses;
     private Map<DotName, List<ClassInfo>> implementors;
     private Map<DotName, ClassInfo> classes;
+    private Map<DotName, List<ClassInfo>> users;
     private NameTable names;
     private GenericSignatureParser signatureParser;
 
@@ -267,6 +268,9 @@ public final class Indexer {
 
         if (classes == null)
             classes = new HashMap<DotName, ClassInfo>();
+
+        if (users == null)
+            users = new HashMap<DotName, List<ClassInfo>>();
 
         if (names == null)
             names = new NameTable();
@@ -615,6 +619,24 @@ public final class Indexer {
         }
     }
 
+    private void resolveUsers() {
+        byte[] pool = constantPool;
+        int[] offsets = constantPoolOffsets;
+        
+        for (int offset : offsets) {
+            if (pool[offset] == CONSTANT_CLASS) {
+                int nameIndex = (pool[++offset] & 0xFF) << 8 | (pool[++offset] & 0xFF);
+                DotName usedClass = names.convertToName(decodeUtf8Entry(nameIndex), '/');
+                List<ClassInfo> usersOfClass = users.get(usedClass);
+                if(usersOfClass == null) {
+                    usersOfClass = new ArrayList<ClassInfo>();
+                    users.put(usedClass, usersOfClass);
+                }
+                usersOfClass.add(this.currentClass);
+            }
+        }
+    }
+    
     private void updateTypeTargets() {
         for (Map.Entry<AnnotationTarget, List<TypeAnnotationState>> entry : typeAnnotations.entrySet()) {
             AnnotationTarget key = entry.getKey();
@@ -1605,6 +1627,7 @@ public final class Indexer {
             applySignatures();
             resolveTypeAnnotations();
             updateTypeTargets();
+            resolveUsers();
 
             currentClass.setMethods(methods, names);
             currentClass.setFields(fields, names);
@@ -1635,13 +1658,14 @@ public final class Indexer {
     public Index complete() {
         initIndexMaps();
         try {
-            return Index.create(masterAnnotations, subclasses, implementors, classes);
+            return Index.create(masterAnnotations, subclasses, implementors, classes, users);
         } finally {
             masterAnnotations = null;
             subclasses = null;
             classes = null;
             signatureParser = null;
             names = null;
+            users = null;
         }
     }
 

--- a/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -36,6 +36,14 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.lang.reflect.Modifier;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.FileVisitor;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.List;
 
@@ -153,6 +161,16 @@ public class BasicTestCase {
         }
     }
 
+    public static class ApiClass {
+        public static void superApi() {}
+    }
+    
+    public static class ApiUser {
+        public void f() {
+            ApiClass.superApi();
+        }
+    }
+    
     @Test
     public void testIndexer() throws IOException {
         Indexer indexer = new Indexer();
@@ -269,17 +287,17 @@ public class BasicTestCase {
     @Test
     public void testSimpleName() throws IOException  {
         class MyLocal{}
-        assertEquals("NestedC", getIndexForClass(NestedC.class)
+        assertEquals("NestedC", getIndexForClasses(NestedC.class)
                                 .getClassByName(DotName.createSimple(NestedC.class.getName())
                                 ).simpleName());
-        assertEquals("BasicTestCase", getIndexForClass(BasicTestCase.class)
+        assertEquals("BasicTestCase", getIndexForClasses(BasicTestCase.class)
                                         .getClassByName(DotName.createSimple(BasicTestCase.class.getName())
                                         ).simpleName());
-        assertEquals("MyLocal", getIndexForClass(MyLocal.class)
+        assertEquals("MyLocal", getIndexForClasses(MyLocal.class)
                                         .getClassByName(DotName.createSimple(MyLocal.class.getName())
                                         ).simpleName());
         Class<?> anon = new Object(){}.getClass();
-        assertEquals(null, getIndexForClass(anon)
+        assertEquals(null, getIndexForClasses(anon)
                                         .getClassByName(DotName.createSimple(anon.getName())
                                         ).simpleName());
     }
@@ -448,32 +466,110 @@ public class BasicTestCase {
     }
 
     private void assertHasNoArgsConstructor(Class<?> clazz, boolean result) throws IOException {
-        ClassInfo classInfo = getIndexForClass(clazz).getClassByName(DotName.createSimple(clazz.getName()));
+        ClassInfo classInfo = getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
         assertNotNull(classInfo);
         assertThat(classInfo.hasNoArgsConstructor(), is(result));
     }
 
     private void assertFlagSet(Class<?> clazz, int flag, boolean result) throws IOException {
-        ClassInfo classInfo = getIndexForClass(clazz).getClassByName(DotName.createSimple(clazz.getName()));
+        ClassInfo classInfo = getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
         assertNotNull(classInfo);
         assertTrue((classInfo.flags() & flag) == (result ? flag : 0));
     }
 
     private void assertNesting(Class<?> clazz, ClassInfo.NestingType nesting, boolean result) throws IOException {
-        ClassInfo classInfo = getIndexForClass(clazz).getClassByName(DotName.createSimple(clazz.getName()));
+        ClassInfo classInfo = getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
         assertNotNull(classInfo);
         assertThat(classInfo.nestingType(), result ? is(nesting) : not(nesting));
     }
 
-    static Index getIndexForClass(Class<?> clazz) throws IOException {
+    static Index getIndexForClasses(Class<?>... classes) throws IOException {
         Indexer indexer = new Indexer();
-        InputStream stream = clazz.getClassLoader().getResourceAsStream(clazz.getName().replace('.', '/') + ".class");
-        indexer.index(stream);
+        for (Class<?> klass : classes) {
+            InputStream stream = klass.getClassLoader().getResourceAsStream(klass.getName().replace('.', '/') + ".class");
+            indexer.index(stream);
+        }
         return indexer.complete();
     }
     
     static ClassInfo getClassInfo(Class<?> clazz) throws IOException {
-        return getIndexForClass(clazz).getClassByName(DotName.createSimple(clazz.getName()));
+        return getIndexForClasses(clazz).getClassByName(DotName.createSimple(clazz.getName()));
     }
 
+    @Test
+    public void testClassConstantIndexing() throws IOException, URISyntaxException {
+        Index index = getIndexForClasses(DummyClass.class, ApiClass.class, ApiUser.class);
+        DotName apiClassDotName = DotName.createSimple(ApiClass.class.getName());
+        List<ClassInfo> users = index.getKnownUsers(apiClassDotName );
+        assertEquals(2, users.size());
+        ClassInfo apiUserClassInfo = index.getClassByName(DotName.createSimple(ApiUser.class.getName()));
+        assertTrue(users.contains(apiUserClassInfo));
+        ClassInfo apiClassInfo = index.getClassByName(apiClassDotName);
+        assertTrue(users.contains(apiClassInfo));
+
+        Index readIndex = testClassConstantSerialisation(index, -1);
+        List<ClassInfo> readUsers = readIndex.getKnownUsers(apiClassDotName );
+        assertEquals(2, readUsers.size());
+        ClassInfo readApiUserClassInfo = readIndex.getClassByName(DotName.createSimple(ApiUser.class.getName()));
+        assertTrue(readUsers.contains(readApiUserClassInfo));
+        ClassInfo readApiClassInfo = readIndex.getClassByName(apiClassDotName);
+        assertTrue(readUsers.contains(readApiClassInfo));
+
+        Index readOldIndex = testClassConstantSerialisation(index, 9);
+        assertEquals(0, readOldIndex.getKnownUsers(apiClassDotName).size());
+        
+        Index allClasses = index(getClass().getProtectionDomain().getCodeSource().getLocation(),
+              Index.class.getProtectionDomain().getCodeSource().getLocation());
+        System.err.println("Indexed "+allClasses.getKnownClasses().size()+" classes");
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        System.err.println("V9 size: "+new IndexWriter(baos).write(index, 9));
+        baos = new ByteArrayOutputStream();
+        System.err.println("V10 size: "+new IndexWriter(baos).write(index));
+    }
+
+    private Index index(URL... locations) throws URISyntaxException, IOException {
+        final Indexer indexer = new Indexer();
+        final ClassLoader cl = BasicTestCase.class.getClassLoader();
+
+        for(URL url : locations) {
+            final Path path = Paths.get(url.toURI());
+            Files.walkFileTree(path, new FileVisitor<Path>() {
+
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    String name = file.toString();
+                    if(name.endsWith(".class")) {
+                        InputStream stream = cl.getResourceAsStream(path.relativize(file).toString());
+                        indexer.index(stream);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+                
+            });
+        }
+
+        return indexer.complete();
+    }
+
+    private Index testClassConstantSerialisation(Index index, int version) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        int ignore = (version == -1) ? new IndexWriter(baos).write(index) : new IndexWriter(baos).write(index, version);
+
+        return new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+    }
 }

--- a/src/test/java/org/jboss/jandex/test/CompositeTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/CompositeTestCase.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
@@ -96,7 +97,8 @@ public class CompositeTestCase {
         Map<DotName,List<ClassInfo>> subclasses = new HashMap<DotName, List<ClassInfo>>();
         subclasses.put(OBJECT_NAME, Collections.singletonList(baseInfo));
         subclasses.put(baseName, Collections.singletonList(classInfo));
+        Map<DotName, List<ClassInfo>> users = Collections.emptyMap();
 
-        return Index.create(annotations, subclasses, implementors, classes);
+        return Index.create(annotations, subclasses, implementors, classes, users);
     }
 }


### PR DESCRIPTION
So I index all types used in the Constant Pool as Class Constants, and make a Map from the used type to the user of the type as a `ClassInfo`.

I thought about mapping to `DotName` but given that they can only belong to the index (since we indexed them), it's not clear that it's worth it.

I thought about mapping to a `Set<ClassInfo>` but that type doesn't implement hashCode/equals and so it was lying. In the end I've gone like most parts of the API (I did see a `Set<ClassInfo>` somewhere but it was alone) and used `List` even though there are no duplicates. At least the type doesn't lie about unicity, though it lies about ordering.

I've a question wrt `Index.create()` which is a `static public` method, so probably I'll need an overload for backwards compat, to accomodate for the new extra param, right?

As for the index format, I've bumped to V10, and tucked a `Map<DotName,List<DotName>>` right after the type list.

This should be all tested.

I'll add docs and remove the index size test once we agree on how to proceed with this PR.

Let me know what you think.