### PR TITLE
Add DotName.packagePrefix() method

### DIFF
--- a/src/main/java/org/jboss/jandex/DotName.java
+++ b/src/main/java/org/jboss/jandex/DotName.java
@@ -180,6 +180,24 @@ public final class DotName implements Comparable<DotName> {
         builder.append(local);
     }
 
+
+    /**
+     * Returns the package portion of this DotName.
+     *
+     * @return the package name or null if this {@link DotName} has no package prefix
+     * @since 2.3.0
+     */
+    public String packagePrefix() {
+        if (componentized) {
+            if (innerClass) {
+                return prefix.packagePrefix();
+            }
+            return prefix.toString();
+        } else {
+            int index = local.lastIndexOf('.');
+            return index == -1 ? null : local.substring(0, index);
+        }
+    }
     /**
      * Returns whether this DotName is a componentized variant.
      *
@@ -357,7 +375,7 @@ public final class DotName implements Comparable<DotName> {
             if (exactToMatch.charAt(cursor) != expectNext) {
                 return false;
             }
-            
+
             current=current.prefix;
         }
         //And finally, verify we consumed it all:

--- a/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
@@ -20,6 +20,7 @@ package org.jboss.jandex.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNull;
 
 import java.util.Iterator;
 import java.util.Random;
@@ -101,6 +102,20 @@ public class DotNameTestCase {
         assertEquals("root.thefoo.Foo$Inner$Inner2", inner2.toString());
         assertEquals("Foo", DotName.createSimple("root.Foo").withoutPackagePrefix());
     }
+
+    @Test
+    public void testpackgePrefix() {
+        DotName foo = DotName.createComponentized(DotName.createComponentized(null, "root"), "thefoo");
+        foo = DotName.createComponentized(foo, "Foo");
+        assertEquals("root.thefoo", foo.packagePrefix());
+        DotName inner = DotName.createComponentized(foo, "Inner", true);
+        DotName inner2 = DotName.createComponentized(inner, "Inner2", true);
+        assertEquals("root.thefoo", inner.packagePrefix());
+        assertEquals("root.thefoo", inner2.packagePrefix());
+        assertEquals("foo.bar.baz", DotName.createSimple("foo.bar.baz.Foo").packagePrefix());
+        assertNull(DotName.createSimple("Foo").packagePrefix());
+    }
+
 
     @Test
     public void testForNaturalComparator() {


### PR DESCRIPTION
I needed this several times in the past when filtering classes by package name. This nicely completes the existing `withoutPackagePrefix()` method.