### PR TITLE
Workaround invalid bytecode generated by java8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.jboss.jandex</groupId>
             <artifactId>typeannotation-test</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>
@@ -158,7 +158,7 @@
                 <enabled>true</enabled>
             </releases>
             <snapshots>
-                <enabled>false</enabled>
+                <enabled>true</enabled>
             </snapshots>
         </repository>
     </repositories>

--- a/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
@@ -72,6 +72,34 @@ public class TypeParameterBoundTestCase {
                 info.typeParameters().get(0).toString());
     }
 
+
+    @Test
+    public void classExtendsOnInner() throws IOException {
+        Indexer indexer = new Indexer();
+        ClassInfo info = indexer.index(getClassBytes("test/TypeParameterBoundExample$IteratorSupplier.class"));
+        Assert.assertEquals("java.util.function.Supplier<java.util.function.Consumer<@Nullable java.lang.Object[]>>",
+                            info.interfaceTypes().get(0).toString());
+    }
+
+    @Test
+    public void classExtendsOnAnonInInner() throws IOException {
+        Indexer indexer = new Indexer();
+        ClassInfo info = indexer.index(getClassBytes("test/TypeParameterBoundExample$IteratorSupplier$1.class"));
+        Assert.assertEquals("java.util.function.Consumer<@Nullable java.lang.Object[]>",
+                           info.interfaceTypes().get(0).toString());
+    }
+
+    @Test
+    public void classExtendsNestAnonExtendsInner() throws IOException {
+        Indexer indexer = new Indexer();
+        ClassInfo info = indexer.index(getClassBytes("test/TypeParameterBoundExample$Nest1$Nest2$Nest3$1$1.class"));
+        Assert.assertEquals("test.TypeParameterBoundExample$Nest1<java.lang.String>.Nest2<java.lang.Object[]>.Nest3<@Nullable java.lang.Integer>",
+                    info.superClassType().toString());
+        info = indexer.index(getClassBytes("test/TypeParameterBoundExample$Nest1$Nest2$Nest3$1$2.class"));
+        Assert.assertEquals("test.TypeParameterBoundExample$Nest1<java.lang.String>.Nest2<@Nullable java.lang.Object[]>.Nest3<java.lang.Integer>",
+                           info.superClassType().toString());
+    }
+
     @Test
     public void serializableListConsumerDA() throws IOException {
         Indexer indexer = new Indexer();


### PR DESCRIPTION
Java 8 javac generates an invalid type annotation path with duplicate entries on the tail for NESTED/INNER_CLASS elements of the type path when an anonymous inner class extends a type annotated generic type. This fix works around the issue by truncating the entries and hoping for the best. 

The error message now also includes the classname should it occur again.

Fixes #92 