### PR TITLE
Replace original positions binary search with `IdentityHashMap`

### DIFF
--- a/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -720,13 +721,16 @@ public final class ClassInfo implements AnnotationTarget {
     static <T> byte[] sortAndGetPositions(T[] internals, Comparator<T> comparator, NameTable names) {
         final int size = internals.length;
         final boolean storePositions = (size > 1 && size <= MAX_POSITIONS);
-        final T[] keys;
+        final Map<T, Integer> originalPositions;
         final byte[] positions;
 
         if (storePositions) {
-            keys = Arrays.copyOf(internals, size);
+            originalPositions = new IdentityHashMap<T, Integer>(size);
+            for (int i = 0; i < size; i++) {
+                originalPositions.put(internals[i], Integer.valueOf(i));
+            }
         } else {
-            keys = null;
+            originalPositions = null;
         }
 
         Arrays.sort(internals, comparator);
@@ -735,8 +739,8 @@ public final class ClassInfo implements AnnotationTarget {
             positions = new byte[size];
 
             for (int i = 0; i < size; i++) {
-                int position = Arrays.binarySearch(internals, keys[i], comparator);
-                positions[i] = (byte) position;
+                // `positions` stores the new position at the offset of the original position
+                positions[originalPositions.get(internals[i])] = (byte) i;
             }
         } else {
             positions = EMPTY_POSITIONS;


### PR DESCRIPTION
@n1hility - thanks for pointing me in the right direction in your comment on #73. I took a look and it turns out that the binarySearch approach is in fact broken as it relates to bridge methods. I ran into some differences in the index testing with an `IdentityHashMap` and I believe it is a necessary change.

Consider class `com.sun.xml.internal.bind.v2.model.impl.RuntimeBuiltinLeafInfoImpl.UUIDImpl` with the following methods:
```
void                   <init>()
java.util.UUID         parse(java.lang.CharSequence text) throws org.xml.sax.SAXException
java.lang.Object       parse(java.lang.CharSequence)      throws com.sun.xml.internal.bind.api.AccessorException, org.xml.sax.SAXException
java.lang.String       print(java.lang.Object)            throws com.sun.xml.internal.bind.api.AccessorException
java.lang.CharSequence print(java.lang.Object)            throws com.sun.xml.internal.bind.api.AccessorException
java.lang.String       print(java.util.UUID v)]
```

Two of the `print` methods are identical in name and parameter type/name, resulting in incorrect results being placed in the original positions array. I did not notice any significant runtime performance difference between this PR and the original version when indexing JRE 8's rt.jar.