### PR TITLE
Support modules and records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.1</version>
                 <configuration>
                     <debug>true</debug>
                     <source>1.6</source>
@@ -89,7 +88,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>2.3.7</version>
                 <extensions>true</extensions>
                 <configuration>
                     <archive>

--- a/src/main/java/org/jboss/jandex/AnnotationTarget.java
+++ b/src/main/java/org/jboss/jandex/AnnotationTarget.java
@@ -58,7 +58,14 @@ public interface AnnotationTarget {
         /**
          * An object of type {@link org.jboss.jandex.TypeTarget}
          */
-        TYPE}
+        TYPE,
+
+        /**
+         * An object of type {@link org.jboss.jandex.RecordComponentInfo}
+         * @since 2.4
+         */
+        RECORD_COMPONENT
+    }
 
     /**
      * Returns the kind of object this target represents.
@@ -107,5 +114,13 @@ public interface AnnotationTarget {
       * @since 2.0
       */
     TypeTarget asType();
+
+    /**
+     * Casts and returns this target as a <code>RecordComponentInfo</code> if it is of kind <code>RECORD_COMPONENT</code>
+     *
+     * @return this instance cast to a record component
+     * @since 2.4
+     */
+    RecordComponentInfo asRecordComponent();
 
 }

--- a/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -73,7 +73,7 @@ public class CompositeIndex implements IndexView {
         }
         return Collections.unmodifiableList(allInstances);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -213,6 +213,33 @@ public class CompositeIndex implements IndexView {
         final List<ClassInfo> allKnown = new ArrayList<ClassInfo>();
         for (IndexView index : indexes) {
             final Collection<ClassInfo> list = index.getKnownClasses();
+            if (list != null) {
+                allKnown.addAll(list);
+            }
+        }
+        return Collections.unmodifiableCollection(allKnown);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public ModuleInfo getModuleByName(final DotName moduleName) {
+        for (IndexView index : indexes) {
+            final ModuleInfo info = index.getModuleByName(moduleName);
+            if (info != null) {
+                return info;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public Collection<ModuleInfo> getKnownModules() {
+        final List<ModuleInfo> allKnown = new ArrayList<ModuleInfo>();
+        for (IndexView index : indexes) {
+            final Collection<ModuleInfo> list = index.getKnownModules();
             if (list != null) {
                 allKnown.addAll(list);
             }

--- a/src/main/java/org/jboss/jandex/DotName.java
+++ b/src/main/java/org/jboss/jandex/DotName.java
@@ -46,6 +46,7 @@ public final class DotName implements Comparable<DotName> {
     static final DotName JAVA_LANG_NAME;
     static final DotName OBJECT_NAME;
     static final DotName ENUM_NAME;
+    static final DotName RECORD_NAME;
 
     private final DotName prefix;
     private final String local;
@@ -58,6 +59,7 @@ public final class DotName implements Comparable<DotName> {
         JAVA_LANG_NAME = new DotName(JAVA_NAME, "lang", true, false);
         OBJECT_NAME = new DotName(JAVA_LANG_NAME, "Object", true, false);
         ENUM_NAME = new DotName(JAVA_LANG_NAME, "Enum", true, false);
+        RECORD_NAME = new DotName(JAVA_LANG_NAME, "Record", true, false);
     }
 
     /**

--- a/src/main/java/org/jboss/jandex/Index.java
+++ b/src/main/java/org/jboss/jandex/Index.java
@@ -58,15 +58,17 @@ public final class Index implements IndexView {
     final Map<DotName, List<ClassInfo>> subclasses;
     final Map<DotName, List<ClassInfo>> implementors;
     final Map<DotName, ClassInfo> classes;
+    final Map<DotName, ModuleInfo> modules;
     final Map<DotName, List<ClassInfo>> users;
 
     Index(Map<DotName, List<AnnotationInstance>> annotations, Map<DotName, List<ClassInfo>> subclasses,
-          Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes,
+          Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes, Map<DotName, ModuleInfo> modules,
           Map<DotName, List<ClassInfo>> users) {
         this.annotations = Collections.unmodifiableMap(annotations);
         this.classes = Collections.unmodifiableMap(classes);
         this.subclasses = Collections.unmodifiableMap(subclasses);
         this.implementors = Collections.unmodifiableMap(implementors);
+        this.modules = Collections.unmodifiableMap(modules);
         this.users = Collections.unmodifiableMap(users);
     }
 
@@ -85,7 +87,7 @@ public final class Index implements IndexView {
      */
     public static Index create(Map<DotName, List<AnnotationInstance>> annotations, Map<DotName, List<ClassInfo>> subclasses,
                                Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes) {
-        return new Index(annotations, subclasses, implementors, classes, Collections.<DotName, List<ClassInfo>>emptyMap());
+        return new Index(annotations, subclasses, implementors, classes, Collections.<DotName, ModuleInfo>emptyMap(), Collections.<DotName, List<ClassInfo>>emptyMap());
     }
 
     /**
@@ -104,7 +106,7 @@ public final class Index implements IndexView {
     public static Index create(Map<DotName, List<AnnotationInstance>> annotations, Map<DotName, List<ClassInfo>> subclasses,
                                Map<DotName, List<ClassInfo>> implementors, Map<DotName, ClassInfo> classes,
                                Map<DotName, List<ClassInfo>> users) {
-        return new Index(annotations, subclasses, implementors, classes, users);
+        return new Index(annotations, subclasses, implementors, classes, Collections.<DotName, ModuleInfo>emptyMap(), users);
     }
 
     /**
@@ -303,6 +305,22 @@ public final class Index implements IndexView {
      */
     public Collection<ClassInfo> getKnownClasses() {
         return classes.values();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<ModuleInfo> getKnownModules() {
+        return modules.values();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ModuleInfo getModuleByName(DotName moduleName) {
+        return modules.get(moduleName);
     }
 
     /**

--- a/src/main/java/org/jboss/jandex/IndexView.java
+++ b/src/main/java/org/jboss/jandex/IndexView.java
@@ -109,11 +109,11 @@ public interface IndexView {
      * @return a non-null list of annotation instances
      */
     public Collection<AnnotationInstance> getAnnotations(DotName annotationName);
-    
+
     /**
      * Obtains a list of instances for the specified annotation. If the specified annotation is repeatable (JLS 9.6), the result also contains all values from
      * all instances of the container annotation. In this case, the {@link AnnotationInstance#target()} returns the target of the container annotation instance.
-     * 
+     *
      * @throws IllegalArgumentException If the the defining annotation class is not found
      * @param annotationName the name of the repeatable annotation
      * @param index the index containing the annotation class
@@ -121,6 +121,21 @@ public interface IndexView {
      * @throws IllegalArgumentException If the index does not contain the annotation definition or if it does not represent an annotation type
      */
     public Collection<AnnotationInstance> getAnnotationsWithRepeatable(DotName annotationName, IndexView index);
+
+    /**
+     * Gets all known modules by this index (those which were scanned).
+     *
+     * @return a collection of known modules
+     */
+    public Collection<ModuleInfo> getKnownModules();
+
+    /**
+     * Gets the module that was scanned during the indexing phase.
+     *
+     * @param moduleName the name of the module
+     * @return information about the module or null if it is not known
+     */
+    public ModuleInfo getModuleByName(DotName moduleName);
 
     /**
      * Obtains a list of classes that use the specified class. In other words, a list of classes that include

--- a/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -433,6 +433,11 @@ public final class MethodInfo implements AnnotationTarget {
         throw new IllegalArgumentException("Not a type");
     }
 
+    @Override
+    public RecordComponentInfo asRecordComponent() {
+        throw new IllegalArgumentException("Not a record component");
+    }
+
     final MethodInternal methodInternal() {
         return methodInternal;
     }

--- a/src/main/java/org/jboss/jandex/MethodInternal.java
+++ b/src/main/java/org/jboss/jandex/MethodInternal.java
@@ -250,6 +250,7 @@ final class MethodInternal {
         return flags;
     }
 
+    @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
         String name = name();

--- a/src/main/java/org/jboss/jandex/MethodParameterInfo.java
+++ b/src/main/java/org/jboss/jandex/MethodParameterInfo.java
@@ -110,6 +110,11 @@ public final class MethodParameterInfo implements AnnotationTarget {
     }
 
     @Override
+    public RecordComponentInfo asRecordComponent() {
+        throw new IllegalArgumentException("Not a record component");
+    }
+
+    @Override
     public Kind kind() {
         return Kind.METHOD_PARAMETER;
     }

--- a/src/main/java/org/jboss/jandex/ModuleInfo.java
+++ b/src/main/java/org/jboss/jandex/ModuleInfo.java
@@ -1,0 +1,390 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.jandex;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents a module descriptor entry in an index.
+ *
+ * <p><b>Thread-Safety</b></p>
+ * This class is immutable and can be shared between threads without safe publication.
+ *
+ */
+public final class ModuleInfo {
+
+    private static final int OPEN = 0x0020;
+
+    private final ClassInfo moduleInfoClass;
+    private final DotName name;
+    private final short flags;
+    private final String version;
+
+    private DotName mainClass;
+    private List<RequiredModuleInfo> requires;
+    private List<ExportedPackageInfo> exports;
+    private List<OpenedPackageInfo> opens;
+    private List<DotName> uses;
+    private List<ProvidedServiceInfo> provides;
+    private List<DotName> packages;
+
+    ModuleInfo(ClassInfo moduleInfoClass, DotName name, short flags, String version) {
+        this.moduleInfoClass = moduleInfoClass;
+        this.name = name;
+        this.flags = flags;
+        this.version = version;
+        this.packages = Collections.emptyList(); // Initialize
+        moduleInfoClass.setModule(this);
+    }
+
+    public String toString() {
+        return name.toString();
+    }
+
+    public ClassInfo moduleInfoClass() {
+        return moduleInfoClass;
+    }
+
+    /**
+     * Returns the name of the class
+     *
+     * @return the name of the class
+     */
+    public DotName name() {
+        return name;
+    }
+
+    /**
+     * Returns the access flags for this class. The standard {@link java.lang.reflect.Modifier}
+     * can be used to decode the value.
+     *
+     * @return the access flags
+     */
+    public short flags() {
+        return flags;
+    }
+
+    public boolean isOpen() {
+        return (flags & OPEN) != 0;
+    }
+
+    public String version() {
+        return version;
+    }
+
+    public DotName mainClass() {
+        return mainClass;
+    }
+
+    List<RequiredModuleInfo> requiresList() {
+        return requires;
+    }
+
+    public List<RequiredModuleInfo> requires() {
+        return Collections.unmodifiableList(requires);
+    }
+
+    List<ExportedPackageInfo> exportsList() {
+        return exports;
+    }
+
+    public List<ExportedPackageInfo> exports() {
+        return Collections.unmodifiableList(exports);
+    }
+
+    List<OpenedPackageInfo> opensList() {
+        return opens;
+    }
+
+    public List<OpenedPackageInfo> opens() {
+        return Collections.unmodifiableList(opens);
+    }
+
+    List<DotName> usesList() {
+        return uses;
+    }
+
+    public List<DotName> uses() {
+        return Collections.unmodifiableList(uses);
+    }
+
+    List<ProvidedServiceInfo> providesList() {
+        return provides;
+    }
+
+    public List<ProvidedServiceInfo> provides() {
+        return Collections.unmodifiableList(provides);
+    }
+
+    List<DotName> packagesList() {
+        return packages;
+    }
+
+    public List<DotName> packages() {
+        return Collections.unmodifiableList(packages);
+    }
+
+    public final AnnotationInstance annotation(DotName name) {
+        return moduleInfoClass.classAnnotation(name);
+    }
+
+    public final Collection<AnnotationInstance> annotations() {
+        return moduleInfoClass.classAnnotations();
+    }
+
+    public final List<AnnotationInstance> annotationsWithRepeatable(DotName name, IndexView index) {
+        return moduleInfoClass.classAnnotationsWithRepeatable(name, index);
+    }
+
+    void setMainClass(DotName mainClass) {
+        this.mainClass = mainClass;
+    }
+
+    void setRequires(List<RequiredModuleInfo> requires) {
+        this.requires = requires;
+    }
+
+    void setExports(List<ExportedPackageInfo> exports) {
+        this.exports = exports;
+    }
+
+    void setOpens(List<OpenedPackageInfo> opens) {
+        this.opens = opens;
+    }
+
+    void setUses(List<DotName> uses) {
+        this.uses = uses;
+    }
+
+    void setProvides(List<ProvidedServiceInfo> provides) {
+        this.provides = provides;
+    }
+
+    void setPackages(List<DotName> packages) {
+        this.packages = packages;
+    }
+
+    public static final class RequiredModuleInfo {
+        private static final int TRANSITIVE = 0x0020;
+        private static final int STATIC = 0x0040;
+
+        private final DotName name;
+        private final int flags;
+        private final String version;
+
+        RequiredModuleInfo(DotName name, int flags, String version) {
+            this.name = name;
+            this.flags = flags;
+            this.version = version;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder("requires ");
+
+            if (isStatic()) {
+                result.append("static ");
+            }
+
+            if (isTransitive()) {
+                result.append("transitive ");
+            }
+
+            result.append(name.toString());
+
+            if (version != null) {
+                result.append('@');
+                result.append(version);
+            }
+
+            return result.toString();
+        }
+
+        public DotName name() {
+            return name;
+        }
+
+        public int flags() {
+            return flags;
+        }
+
+        public String version() {
+            return version;
+        }
+
+        public boolean isStatic() {
+            return (flags & STATIC) != 0;
+        }
+
+        public boolean isTransitive() {
+            return (flags & TRANSITIVE) != 0;
+        }
+    }
+
+    public static final class ExportedPackageInfo {
+        private final DotName source;
+        private final int flags;
+        private final List<DotName> targets;
+
+        ExportedPackageInfo(DotName source, int flags, List<DotName> targets) {
+            this.source = source;
+            this.flags = flags;
+            this.targets = targets;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder("exports ");
+
+            result.append(source.toString());
+
+            if (!targets.isEmpty()) {
+                result.append(" to ");
+
+                for (int i = 0, m = targets.size(); i < m; i++) {
+                    if (i > 0) {
+                        result.append(", ");
+                    }
+
+                    result.append(targets.get(i));
+                }
+            }
+
+            return result.toString();
+        }
+
+        public DotName source() {
+            return source;
+        }
+
+        public int flags() {
+            return flags;
+        }
+
+        public boolean isQualified() {
+            return !targets.isEmpty();
+        }
+
+        List<DotName> targetsList() {
+            return targets;
+        }
+
+        public List<DotName> targets() {
+            return Collections.unmodifiableList(targets);
+        }
+    }
+
+    public static final class OpenedPackageInfo {
+        private final DotName source;
+        private final int flags;
+        private final List<DotName> targets;
+
+        OpenedPackageInfo(DotName source, int flags, List<DotName> targets) {
+            this.source = source;
+            this.flags = flags;
+            this.targets = targets;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder("opens ");
+
+            result.append(source.toString());
+
+            if (!targets.isEmpty()) {
+                result.append(" to ");
+
+                for (int i = 0, m = targets.size(); i < m; i++) {
+                    if (i > 0) {
+                        result.append(", ");
+                    }
+
+                    result.append(targets.get(i));
+                }
+            }
+
+            return result.toString();
+        }
+
+        public DotName source() {
+            return source;
+        }
+
+        public int flags() {
+            return flags;
+        }
+
+        public boolean isQualified() {
+            return !targets.isEmpty();
+        }
+
+        List<DotName> targetsList() {
+            return targets;
+        }
+
+        public List<DotName> targets() {
+            return Collections.unmodifiableList(targets);
+        }
+    }
+
+    public static final class ProvidedServiceInfo {
+        private final DotName service;
+        private final List<DotName> providers;
+
+        ProvidedServiceInfo(DotName name, List<DotName> providers) {
+            this.service = name;
+            this.providers = providers;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder result = new StringBuilder("provides ");
+
+            result.append(service.toString());
+
+            if (!providers.isEmpty()) {
+                result.append(" with ");
+
+                for (int i = 0, m = providers.size(); i < m; i++) {
+                    if (i > 0) {
+                        result.append(", ");
+                    }
+
+                    result.append(providers.get(i));
+                }
+            }
+
+            return result.toString();
+        }
+
+        public DotName service() {
+            return service;
+        }
+
+        List<DotName> providersList() {
+            return providers;
+        }
+
+        public List<DotName> providers() {
+            return Collections.unmodifiableList(providers);
+        }
+    }
+}

--- a/src/main/java/org/jboss/jandex/NameTable.java
+++ b/src/main/java/org/jboss/jandex/NameTable.java
@@ -33,6 +33,7 @@ class NameTable {
     private StrongInternPool<byte[]> bytePool = new StrongInternPool<byte[]>();
     private StrongInternPool<MethodInternal> methodPool = new StrongInternPool<MethodInternal>();
     private StrongInternPool<FieldInternal> fieldPool = new StrongInternPool<FieldInternal>();
+    private StrongInternPool<RecordComponentInternal> recordComponentPool = new StrongInternPool<RecordComponentInternal>();
     private Map<String, DotName> names = new HashMap<String, DotName>();
 
     DotName convertToName(String name) {
@@ -112,6 +113,14 @@ class NameTable {
         return fieldPool.index().positionOf(fieldInternal);
     }
 
+    RecordComponentInternal intern(RecordComponentInternal recordComponentInternal) {
+        return recordComponentPool.intern(recordComponentInternal);
+    }
+
+    int positionOf(RecordComponentInternal recordComponentInternal) {
+        return recordComponentPool.index().positionOf(recordComponentInternal);
+    }
+
     StrongInternPool<String> stringPool() {
         return stringPool;
     }
@@ -126,6 +135,10 @@ class NameTable {
 
     StrongInternPool<FieldInternal> fieldPool() {
         return fieldPool;
+    }
+
+    StrongInternPool<RecordComponentInternal> recordComponentPool() {
+        return recordComponentPool;
     }
 
     DotName intern(DotName dotName, char delim) {

--- a/src/main/java/org/jboss/jandex/RecordComponentInfoGenerator.java
+++ b/src/main/java/org/jboss/jandex/RecordComponentInfoGenerator.java
@@ -1,0 +1,48 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2021 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jboss.jandex;
+
+import java.util.AbstractList;
+
+/**
+ * A list which wraps RecordComponentInternal objects with a RecordComponentInfo,
+ * so that the declaring class' reference can be set. This lazy construction
+ * is used to conserve memory usage.
+ */
+class RecordComponentInfoGenerator extends AbstractList<RecordComponentInfo> {
+    private final RecordComponentInternal[] recordComponents;
+    private final ClassInfo clazz;
+    private final byte[] positions;
+
+    public RecordComponentInfoGenerator(ClassInfo clazz, RecordComponentInternal[] recordComponents, byte[] positions) {
+        this.clazz = clazz;
+        this.recordComponents = recordComponents;
+        this.positions = positions;
+    }
+
+    @Override
+    public RecordComponentInfo get(int i) {
+        RecordComponentInternal recordComponent = (positions.length > 0) ? recordComponents[positions[i] & 0xFF] : recordComponents[i];
+        return new RecordComponentInfo(clazz, recordComponent);
+    }
+
+    @Override
+    public int size() {
+        return recordComponents.length;
+    }
+}

--- a/src/main/java/org/jboss/jandex/RecordComponentInternal.java
+++ b/src/main/java/org/jboss/jandex/RecordComponentInternal.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source.
- * Copyright 2013 Red Hat, Inc., and individual contributors
+ * Copyright 2021 Red Hat, Inc., and individual contributors
  * as indicated by the @author tags.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,45 +24,40 @@ import java.util.Comparator;
 import java.util.List;
 
 /**
- * The shared internal representation for FieldInfo objects.
- *
- * @author Jason T. Greene
+ * The shared internal representation for RecordComponentInfo objects.
  */
-final class FieldInternal {
-    static final FieldInternal[] EMPTY_ARRAY = new FieldInternal[0];
+final class RecordComponentInternal {
+    static final RecordComponentInternal[] EMPTY_ARRAY = new RecordComponentInternal[0];
     private final byte[] name;
     private Type type;
-    private final short flags;
     private AnnotationInstance[] annotations;
 
     static final NameComparator NAME_COMPARATOR = new NameComparator();
 
-    static class NameComparator implements Comparator<FieldInternal> {
-
+    static class NameComparator implements Comparator<RecordComponentInternal> {
         private int compare(byte[] left, byte[] right) {
-               for (int i = 0, j = 0; i < left.length && j < right.length; i++, j++) {
-                   int a = (left[i] & 0xff);
-                   int b = (right[j] & 0xff);
-                   if (a != b) {
-                       return a - b;
-                   }
-               }
-               return left.length - right.length;
-           }
+            for (int i = 0, j = 0; i < left.length && j < right.length; i++, j++) {
+                int a = (left[i] & 0xff);
+                int b = (right[j] & 0xff);
+                if (a != b) {
+                    return a - b;
+                }
+            }
+            return left.length - right.length;
+        }
 
-        public int compare(FieldInternal instance, FieldInternal instance2) {
+        public int compare(RecordComponentInternal instance, RecordComponentInternal instance2) {
             return compare(instance.name, instance2.name); //instance.name.compareTo(instance2.name);
         }
     }
 
-    FieldInternal(byte[] name, Type type, short flags) {
-        this(name, type, flags, AnnotationInstance.EMPTY_ARRAY);
+    RecordComponentInternal(byte[] name, Type type) {
+        this(name, type, AnnotationInstance.EMPTY_ARRAY);
     }
 
-    FieldInternal(byte[] name, Type type, short flags, AnnotationInstance[] annotations) {
+    RecordComponentInternal(byte[] name, Type type, AnnotationInstance[] annotations) {
         this.name = name;
         this.type = type;
-        this.flags = flags;
         this.annotations = annotations;
     }
 
@@ -75,11 +70,8 @@ final class FieldInternal {
             return false;
         }
 
-        FieldInternal that = (FieldInternal) o;
+        RecordComponentInternal that = (RecordComponentInternal) o;
 
-        if (flags != that.flags) {
-            return false;
-        }
         if (!Arrays.equals(annotations, that.annotations)) {
             return false;
         }
@@ -97,7 +89,6 @@ final class FieldInternal {
     public int hashCode() {
         int result = Arrays.hashCode(name);
         result = 31 * result + type.hashCode();
-        result = 31 * result + (int) flags;
         result = 31 * result + Arrays.hashCode(annotations);
         return result;
     }
@@ -130,10 +121,6 @@ final class FieldInternal {
 
     final boolean hasAnnotation(DotName name) {
         return annotation(name) != null;
-    }
-
-    final short flags() {
-        return flags;
     }
 
     @Override

--- a/src/main/java/org/jboss/jandex/TypeTarget.java
+++ b/src/main/java/org/jboss/jandex/TypeTarget.java
@@ -192,4 +192,10 @@ public abstract class TypeTarget implements AnnotationTarget {
     public final TypeTarget asType() {
         return this;
     }
+
+    @Override
+    public RecordComponentInfo asRecordComponent() {
+        throw new IllegalArgumentException("Not a record component");
+    }
+
 }

--- a/src/main/java/org/jboss/jandex/Utils.java
+++ b/src/main/java/org/jboss/jandex/Utils.java
@@ -19,6 +19,7 @@
 package org.jboss.jandex;
 
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -51,4 +52,9 @@ class Utils {
     static <K, V> Map<K, V> emptyOrWrap(Map<K, V> map) {
         return map.size() == 0 ? Collections.<K, V>emptyMap() : Collections.unmodifiableMap(map);
     }
+
+    static <T> List<T> listOfCapacity(int capacity) {
+        return capacity > 0 ? new ArrayList<T>(capacity) : Collections.<T>emptyList();
+    }
+
 }

--- a/src/test/java/org/jboss/jandex/test/AnnotationInstanceFilterTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/AnnotationInstanceFilterTestCase.java
@@ -18,9 +18,6 @@
 
 package org.jboss.jandex.test;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -35,11 +32,9 @@ import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
-import org.jboss.jandex.Index;
-import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
-import org.jboss.jandex.Type;
+import org.jboss.jandex.RecordComponentInfo;
 import org.jboss.jandex.TypeTarget;
 import org.junit.Assert;
 import org.junit.Test;
@@ -75,6 +70,11 @@ public class AnnotationInstanceFilterTestCase {
         public TypeTarget asType() {
             return null;
         }
+
+        @Override
+        public RecordComponentInfo asRecordComponent() {
+            return null;
+        }
     }
     private static class Miss implements AnnotationTarget{
         @Override
@@ -104,6 +104,11 @@ public class AnnotationInstanceFilterTestCase {
 
         @Override
         public TypeTarget asType() {
+            return null;
+        }
+
+        @Override
+        public RecordComponentInfo asRecordComponent() {
             return null;
         }
     }

--- a/src/test/java/org/jboss/jandex/test/ModuleInfoTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/ModuleInfoTestCase.java
@@ -1,0 +1,158 @@
+/*
+ * JBoss, Home of Professional Open Source. Copyright 2021 Red Hat, Inc., and
+ * individual contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.jboss.jandex.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.ModuleInfo;
+import org.jboss.jandex.ModuleInfo.ExportedPackageInfo;
+import org.jboss.jandex.ModuleInfo.OpenedPackageInfo;
+import org.jboss.jandex.ModuleInfo.ProvidedServiceInfo;
+import org.jboss.jandex.ModuleInfo.RequiredModuleInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ModuleInfoTestCase {
+
+    ModuleInfo mod;
+
+    @Before
+    public void setup() throws IOException {
+        mod = indexModuleInfo();
+    }
+
+    @Test
+    public void testModuleAnnotations() throws IOException {
+        ModuleInfo mod = indexModuleInfo();
+        Map<DotName, List<AnnotationInstance>> annotations = mod.moduleInfoClass().annotations();
+        assertEquals(2, annotations.size());
+        assertEquals(1, annotations.get(DotName.createSimple(Deprecated.class.getName())).size());
+        assertEquals(1, annotations.get(DotName.createSimple("test.ModuleAnnotation")).size());
+    }
+
+    @Test
+    public void testModulePackagesListed() throws IOException {
+        ModuleInfo mod = indexModuleInfo();
+        List<DotName> expected = Arrays.asList(DotName.createSimple("test"),
+                                               DotName.createSimple("test.exec"));
+        assertEquals(expected.size(), mod.packages().size());
+        for (DotName e : expected) {
+            assertTrue(mod.packages().contains(e));
+        }
+    }
+
+    @Test
+    public void testModuleRequires() {
+        List<RequiredModuleInfo> requires = mod.requires();
+        assertEquals(2, requires.size());
+        assertEquals("java.base", requires.get(0).name().toString());
+        assertEquals("java.desktop", requires.get(1).name().toString());
+        assertTrue(requires.get(1).isTransitive());
+    }
+
+    @Test
+    public void testModuleExports() {
+        List<ExportedPackageInfo> exports = mod.exports();
+        assertEquals(1, exports.size());
+        assertEquals("test", exports.get(0).source().toString());
+        assertEquals("java.base", exports.get(0).targets().get(0).toString());
+        assertEquals("java.desktop", exports.get(0).targets().get(1).toString());
+    }
+
+    @Test
+    public void testModuleOpens() {
+        List<OpenedPackageInfo> opens = mod.opens();
+        assertEquals(2, opens.size());
+        assertEquals("test", opens.get(0).source().toString());
+        assertEquals("java.base", opens.get(0).targets().get(0).toString());
+        assertEquals("test.exec", opens.get(1).source().toString());
+        assertEquals("java.base", opens.get(1).targets().get(0).toString());
+    }
+
+    @Test
+    public void testModuleProvides() {
+        List<ProvidedServiceInfo> provides = mod.provides();
+        assertEquals(1, provides.size());
+        assertEquals("test.ServiceProviderExample", provides.get(0).service().toString());
+        assertEquals("test.ServiceProviderExample$ServiceProviderExampleImpl",
+                     provides.get(0).providers().get(0).toString());
+    }
+
+    @Test
+    public void testModuleUses() {
+        List<DotName> uses = mod.uses();
+        assertEquals(1, uses.size());
+        assertEquals("test.ServiceProviderExample", uses.get(0).toString());
+    }
+
+    @Test
+    public void testModuleMainClass() {
+        assertNotNull(mod.mainClass());
+        assertEquals("test.exec.Main", mod.mainClass().toString());
+    }
+
+    private ModuleInfo indexModuleInfo() throws IOException {
+        Index index = buildIndex();
+        return index.getModuleByName(DotName.createSimple("org.jboss.jandex.typeannotationtest"));
+    }
+
+    private Index buildIndex() throws IOException {
+        Indexer indexer = new Indexer();
+        indexAvailableModuleInfo(indexer);
+
+        Index index = indexer.complete();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new IndexWriter(baos).write(index);
+
+        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+
+        return index;
+    }
+
+    /**
+     * Index all module-info.class files on the classpath.
+     *
+     * @param indexer the Indexer where the module-info.class will be added
+     * @throws IOException
+     */
+    static void indexAvailableModuleInfo(Indexer indexer) throws IOException {
+        Enumeration<URL> modules = ModuleInfoTestCase.class.getClassLoader().getResources("module-info.class");
+
+        while (modules.hasMoreElements()) {
+            URL module = modules.nextElement();
+            indexer.index(module.openStream());
+        }
+    }
+}

--- a/src/test/java/org/jboss/jandex/test/RecordTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/RecordTestCase.java
@@ -1,0 +1,165 @@
+/*
+ * JBoss, Home of Professional Open Source. Copyright 2021 Red Hat, Inc., and
+ * individual contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package org.jboss.jandex.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.RecordComponentInfo;
+import org.junit.Before;
+import org.junit.Test;
+
+public class RecordTestCase {
+
+    Index index;
+
+    @Before
+    public void setup() throws IOException {
+        index = buildIndex();
+    }
+
+    @Test
+    public void testRecordHasAnnotation() {
+        DotName recordAnnotation = DotName.createSimple("test.RecordExample$RecordAnnotation");
+
+        ClassInfo rec = index.getClassByName(DotName.createSimple("test.RecordExample"));
+        assertNotNull(rec);
+        assertTrue(rec.isRecord());
+        AnnotationInstance anno = rec.classAnnotation(recordAnnotation);
+        assertNotNull(anno);
+        assertEquals("Example", anno.value().asString());
+
+        ClassInfo nestedRec = index.getClassByName(DotName.createSimple("test.RecordExample$NestedEmptyRecord"));
+        assertNotNull(rec);
+        assertTrue(rec.isRecord());
+        assertEquals(ClassInfo.NestingType.INNER, nestedRec.nestingType());
+        assertEquals("Empty", nestedRec.classAnnotation(recordAnnotation).value().asString());
+
+    }
+
+    @Test
+    public void testRecordComponentHasAnnotation() {
+        ClassInfo rec = index.getClassByName(DotName.createSimple("test.RecordExample"));
+        List<AnnotationInstance> componentAnnos = rec.annotations().get(DotName.createSimple("test.RecordExample$ComponentAnnotation"));
+        assertNotNull(componentAnnos);
+        assertEquals(1, componentAnnos.size());
+        assertEquals(AnnotationTarget.Kind.RECORD_COMPONENT, componentAnnos.get(0).target().kind());
+        assertEquals("name", componentAnnos.get(0).target().asRecordComponent().name());
+        assertEquals("nameComponent", componentAnnos.get(0).value().asString());
+
+        assertEquals(2, rec.recordComponents().size());
+
+        RecordComponentInfo idComponent = rec.recordComponent("id");
+        assertNotNull(idComponent);
+        List<AnnotationInstance> idAnnotations = idComponent.annotations();
+        assertNotNull(idAnnotations);
+        assertEquals(1, idAnnotations.size());
+        assertEquals(AnnotationTarget.Kind.TYPE, idAnnotations.get(0).target().kind());
+        assertEquals("test.Nullable", idAnnotations.get(0).name().toString());
+
+        RecordComponentInfo nameComponent = rec.recordComponent("name");
+        assertNotNull(nameComponent);
+        List<AnnotationInstance> nameAnnotations = nameComponent.annotations();
+        assertNotNull(nameAnnotations);
+        assertEquals(2, nameAnnotations.size());
+        assertEquals(AnnotationTarget.Kind.TYPE, nameAnnotations.get(0).target().kind());
+        assertEquals("test.Nullable", nameAnnotations.get(0).name().toString());
+        assertEquals(AnnotationTarget.Kind.RECORD_COMPONENT, nameAnnotations.get(1).target().kind());
+        assertEquals("name", nameAnnotations.get(1).target().asRecordComponent().name());
+        assertEquals("test.RecordExample$ComponentAnnotation", nameAnnotations.get(1).name().toString());
+        assertEquals("nameComponent", nameAnnotations.get(1).value().asString());
+
+        assertNull(rec.recordComponent("nonexisting"));
+    }
+
+    @Test
+    public void testComponentFieldHasAnnotation() {
+        ClassInfo rec = index.getClassByName(DotName.createSimple("test.RecordExample"));
+
+        List<AnnotationInstance> idAnnotations = rec.field("id").annotations();
+        assertNotNull(idAnnotations);
+        assertEquals(1, idAnnotations.size());
+        assertEquals(AnnotationTarget.Kind.TYPE, idAnnotations.get(0).target().kind());
+        assertEquals("test.Nullable", idAnnotations.get(0).name().toString());
+
+        List<AnnotationInstance> nameAnnotations = rec.field("name").annotations();
+        assertNotNull(nameAnnotations);
+        assertEquals(2, nameAnnotations.size());
+        assertEquals(AnnotationTarget.Kind.TYPE, nameAnnotations.get(0).target().kind());
+        assertEquals("test.Nullable", nameAnnotations.get(0).name().toString());
+        assertEquals(AnnotationTarget.Kind.FIELD, nameAnnotations.get(1).target().kind());
+        assertEquals("name", nameAnnotations.get(1).target().asField().name());
+        assertEquals("test.RecordExample$FieldAnnotation", nameAnnotations.get(1).name().toString());
+        assertEquals("nameField", nameAnnotations.get(1).value().asString());
+    }
+
+    @Test
+    public void testComponentAccessorHasAnnotation() {
+        ClassInfo rec = index.getClassByName(DotName.createSimple("test.RecordExample"));
+
+        List<AnnotationInstance> idAnnotations = rec.method("id").annotations();
+        assertNotNull(idAnnotations);
+        assertEquals(1, idAnnotations.size());
+        assertEquals(AnnotationTarget.Kind.TYPE, idAnnotations.get(0).target().kind());
+        assertEquals("test.Nullable", idAnnotations.get(0).name().toString());
+
+        List<AnnotationInstance> nameAnnotations = rec.method("name").annotations();
+        assertNotNull(nameAnnotations);
+        assertEquals(2, nameAnnotations.size());
+        assertEquals(AnnotationTarget.Kind.TYPE, nameAnnotations.get(0).target().kind());
+        assertEquals("test.Nullable", nameAnnotations.get(0).name().toString());
+        assertEquals(AnnotationTarget.Kind.METHOD, nameAnnotations.get(1).target().kind());
+        assertEquals("name", nameAnnotations.get(1).target().asMethod().name());
+        assertEquals("test.RecordExample$AccessorAnnotation", nameAnnotations.get(1).name().toString());
+        assertEquals("nameAccessor", nameAnnotations.get(1).value().asString());
+    }
+
+    private Index buildIndex() throws IOException {
+        Indexer indexer = new Indexer();
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$NestedEmptyRecord.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$RecordAnnotation.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$ComponentAnnotation.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$FieldAnnotation.class"));
+        indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$AccessorAnnotation.class"));
+
+        Index index = indexer.complete();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new IndexWriter(baos).write(index);
+
+        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+
+        return index;
+    }
+
+}

--- a/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
@@ -71,6 +71,11 @@ public class TypeAnnotationTestCase {
         indexer.index(stream);
         stream = getClass().getClassLoader().getResourceAsStream("test/VExample$1Fun.class");
         indexer.index(stream);
+        stream = getClass().getClassLoader().getResourceAsStream("test/RecordExample.class");
+        indexer.index(stream);
+        stream = getClass().getClassLoader().getResourceAsStream("test/RecordExample$NestedEmptyRecord.class");
+        indexer.index(stream);
+        ModuleInfoTestCase.indexAvailableModuleInfo(indexer);
 
         return indexer.complete();
     }


### PR DESCRIPTION
Adds support for the scanning of `module-info` class files (JDK 9+) as well as annotations on record components (GA JDK 16).

- New `ModuleInfo` model referenced from its parent `ClassInfo`'s `nestingInfo`. Annotations from the Java `module` are still present on the `ClassInfo`, but having the `ModuleInfo` model with the descriptor details is a "nice to have" to support other potential use cases
- Index modules separately from classes
- Add `AnnotationTarget.Kind.RECORD_COMPONENT`
- Add new `RecordComponentInfo` implementation of `AnnotationTarget`. Annotations on record components can be accessed very similarly to the way annotations on method parameters are accessed. I.e., retrieve the class's annotations and identify those with a `target.kind()` of `Kind.RECORD_COMPONENT`. The component's associated `ClassInfo` and `FieldInfo` can be obtained directly from `RecordComponentInfo`

If this approach looks reasonable/acceptable, I can also go back and add JavaDocs where missing and do some additional research/optimizations if necessary. Note that the build will fail prior to a release of typeannotation-test with the changes from wildfly/typeannotation-test#1.
