### PR TITLE
Include relevant type-use annotations in MethodInfo/FieldInfo and fix index writing for TypeTarget

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>org.jboss.jandex</groupId>
             <artifactId>typeannotation-test</artifactId>
-            <version>1.6</version>
+            <version>1.8</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -644,6 +644,9 @@ final class IndexReaderV2 extends IndexReaderImpl {
         // This update is possible since annotations on a non-null target are unique and not shared
         for (AnnotationInstance annotation : annotations) {
             AnnotationTarget target = annotation.target();
+            if (target instanceof TypeTarget) {
+                target = ((TypeTarget) target).enclosingTarget();
+            }
             if (target instanceof MethodInfo) {
                 ((MethodInfo)target).setClassInfo(clazz);
             } else if (target instanceof MethodParameterInfo) {

--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -1258,7 +1258,9 @@ public final class Indexer {
             recordAnnotation(classAnnotations, annotationName, instance);
             recordAnnotation(masterAnnotations, annotationName, instance);
 
-            if (target instanceof FieldInfo || target instanceof MethodInfo || target instanceof MethodParameterInfo) {
+            if (target instanceof FieldInfo || target instanceof MethodInfo || target instanceof MethodParameterInfo
+                    || target instanceof TypeTarget
+                            && ((TypeTarget) target).enclosingTarget().kind() != AnnotationTarget.Kind.CLASS) {
                 elementAnnotations.add(instance);
             }
         }

--- a/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
@@ -154,7 +154,7 @@ public class TypeAnnotationTestCase {
         assertEquals("SU", type.asTypeVariable().identifier());
         type = type.asTypeVariable().bounds().get(0);
         assertEquals(Type.Kind.CLASS, type.kind());
-        verifyName("java.lang.String", type);
+        verifyName("java.lang.CharSequence", type);
 
         type = parameters.get(1);
         verifyHasAnnotation(nestName(referenceClass, "D"), type);
@@ -162,7 +162,7 @@ public class TypeAnnotationTestCase {
         assertEquals("SU", type.asTypeVariable().identifier());
         type = type.asTypeVariable().bounds().get(0);
         assertEquals(Type.Kind.CLASS, type.kind());
-        verifyName("java.lang.String", type);
+        verifyName("java.lang.CharSequence", type);
 
         type = arguments.get(0);
         assertEquals(Type.Kind.TYPE_VARIABLE, type.kind());
@@ -174,7 +174,7 @@ public class TypeAnnotationTestCase {
         assertEquals("SU", type.asTypeVariable().identifier());
         type = type.asTypeVariable().bounds().get(0);
         assertEquals(Type.Kind.CLASS, type.kind());
-        verifyName("java.lang.String", type);
+        verifyName("java.lang.CharSequence", type);
 
         type = arguments.get(1);
         verifyHasAnnotation(nestName(referenceClass, "A"), type);

--- a/src/test/java/org/jboss/jandex/test/TypeUseTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/TypeUseTestCase.java
@@ -1,0 +1,136 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.jandex.test;
+
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.AnnotationTarget;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.jboss.jandex.TypeTarget;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Serializable;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TypeUseTestCase {
+
+
+    private static final String TEST_SUBJECT_CLAZZ = "test.TypeUseExample$TestSubject";
+
+    @Test
+    public void testTypeParameter() throws IOException {
+        doTestTypeUse("test.TypeUseExample$TypeParameterAnnotation", TypeTarget.Usage.TYPE_PARAMETER, AnnotationTarget.Kind.CLASS);
+    }
+
+    @Test
+    public void testTypeParameterBoundType() throws IOException {
+        doTestTypeUse("test.TypeUseExample$TypeParameterBoundTypeAnnotation", TypeTarget.Usage.TYPE_PARAMETER_BOUND, AnnotationTarget.Kind.CLASS);
+    }
+
+    @Test
+    public void testClassExtends() throws IOException {
+        doTestTypeUse("test.TypeUseExample$ClassExtendsAnnotation", TypeTarget.Usage.CLASS_EXTENDS, AnnotationTarget.Kind.CLASS);
+    }
+
+    @Test
+    public void testFieldType() throws IOException {
+        doTestTypeUse("test.TypeUseExample$FieldTypeAnnotation", TypeTarget.Usage.EMPTY, AnnotationTarget.Kind.FIELD);
+    }
+
+    /**
+     * Test annotations that target the type of a parameter
+     * (such as Hibernate Validator's @Valid annotation)
+     * have an accurate representation,
+     * even after being written to / read from an index file.
+     */
+    @Test
+    public void testMethodParameterType() throws IOException {
+        doTestTypeUse("test.TypeUseExample$MethodParameterTypeAnnotation", TypeTarget.Usage.METHOD_PARAMETER, AnnotationTarget.Kind.METHOD);
+    }
+
+    @Test
+    public void testMethodReturnType() throws IOException {
+        doTestTypeUse("test.TypeUseExample$MethodReturnTypeAnnotation", TypeTarget.Usage.EMPTY, AnnotationTarget.Kind.METHOD);
+    }
+
+    @Test
+    public void testMethodThrowsType() throws IOException {
+        doTestTypeUse("test.TypeUseExample$MethodThrowsTypeAnnotation", TypeTarget.Usage.THROWS, AnnotationTarget.Kind.METHOD);
+    }
+
+    private void doTestTypeUse(String annotationClass,
+                               TypeTarget.Usage expectedUsage, AnnotationTarget.Kind expectedEnclosingTargetKind) throws IOException {
+        Indexer indexer = new Indexer();
+        InputStream stream = getClass().getClassLoader().getResourceAsStream(TEST_SUBJECT_CLAZZ.replace('.', '/')+ ".class");
+        indexer.index(stream);
+        Index originalIndex = indexer.complete();
+
+        // This has always worked fine
+        verifyTypeUseAnnotations(originalIndex, annotationClass, expectedUsage, expectedEnclosingTargetKind);
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new IndexWriter(baos).write(originalIndex);
+        Index indexAfterWriteRead = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+
+        // This used to fail with a ClassCastException because after the index was written, then read again,
+        // the enclosing target in MethodParameterTypeTarget became a type,
+        // and enclosingTarget() casts the enclosing target to MethodInfo...
+        verifyTypeUseAnnotations(indexAfterWriteRead, annotationClass, expectedUsage, expectedEnclosingTargetKind);
+    }
+
+    private void verifyTypeUseAnnotations(Index index, String annotationClass,
+                                          TypeTarget.Usage expectedUsage, AnnotationTarget.Kind expectedEnclosingTargetKind) {
+        List<AnnotationInstance> annotations = index.getAnnotations(DotName.createSimple(annotationClass));
+
+        // There must be exactly two copies of the annotation: one for the parameter and one for the parameter type.
+        assertEquals(1, annotations.size());
+        AnnotationInstance annotation = annotations.get(0);
+        assertEquals(AnnotationTarget.Kind.TYPE, annotation.target().kind());
+
+        TypeTarget target = annotation.target().asType();
+        assertEquals(expectedUsage, target.usage());
+
+        // The enclosing target of the type use annotation must be the method/field/etc.
+        // Note this used to fail with a ClassCastException, but only for an index that was written then read again!
+        AnnotationTarget enclosingTarget = target.enclosingTarget();
+        assertEquals(expectedEnclosingTargetKind, enclosingTarget.kind());
+
+        // enclosingTarget()...declaringClass() used to return a null because we forgot to set it when reading an index.
+        if (enclosingTarget.kind() == AnnotationTarget.Kind.METHOD) {
+            assertEquals(TEST_SUBJECT_CLAZZ, enclosingTarget.asMethod().declaringClass().name().toString());
+        } else if (enclosingTarget.kind() == AnnotationTarget.Kind.FIELD) {
+            assertEquals(TEST_SUBJECT_CLAZZ, enclosingTarget.asField().declaringClass().name().toString());
+        }
+    }
+
+}


### PR DESCRIPTION
See the reproducer for the detail of the problem I'm trying to fix. The problem was detected downstream in Quarkus: https://github.com/quarkusio/quarkus/issues/17491

See the message of the second-to-last commit for an explanation of the fix. Copying it here for convenience:

```quote
    Include relevant type-use annotations in MethodInfo/FieldInfo

    First, because that's what the javadoc of MethodInfo advertises.
    For example in the javadoc of
    org.jboss.jandex.MethodInfo#annotations(org.jboss.jandex.DotName):

         * Retrieves annotations declared on this method, by the name of the
           annotation. This includes annotations which are defined against
    method parameters, as
         * well as type annotations declared on any usage within the method
           signature. The <code>target()</code> of the returned annotation
    instances may be used to
         * determine the exact location of the respective annotation
           instance.

    Notice in particular "as well as type annotations declared on any usage
    within the method signature".

    The second, perhaps more important reason, is related to index
    writing/reading.

    In short, putting a reference to the annotation
    instance in the method means the annnotation instance will be
    written/read together with that method, with the (good) consequence
    that org.jboss.jandex.IndexWriterV2#writeTypeTarget will get passed the
    enclosing method as the "caller" parameter, and will now correctly set
    that method as the enclosing target.

    When the annotation instance was not referenced in the method, the
    annotation instance was written together with the enclosing type, so
    org.jboss.jandex.IndexWriterV2#writeTypeTarget got passed that type as
    the "caller" parameter and considered that the type was the enclosing
    target, which is wrong.
```

Note I had to change the project configuration to compile tests with a source/target set to `1.8`. Otherwise I just cannot add a reproducer, since type-use annotations were introduced in Java 8.