### PR TITLE
fix MethodInternal.equals and hashCode

### DIFF
--- a/src/main/java/org/jboss/jandex/MethodInternal.java
+++ b/src/main/java/org/jboss/jandex/MethodInternal.java
@@ -143,6 +143,9 @@ final class MethodInternal {
         if (!returnType.equals(methodInternal.returnType)) {
             return false;
         }
+        if (defaultValue != null ? !defaultValue.equals(methodInternal.defaultValue) : methodInternal.defaultValue != null) {
+            return false;
+        }
         return Arrays.equals(typeParameters, methodInternal.typeParameters);
     }
 
@@ -157,6 +160,7 @@ final class MethodInternal {
         result = 31 * result + Arrays.hashCode(typeParameters);
         result = 31 * result + Arrays.hashCode(annotations);
         result = 31 * result + (int) flags;
+        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
         return result;
     }
 


### PR DESCRIPTION
The `MethodInternal` objects are usually interned, so their
equality and hash code must be correct. Unfortunately, prior
to this commit, the `defaultValue` field was ignored, leading
to `MethodInternal` objects being shared when they shouldn't.