### PR TITLE
[2.3] fix MethodInternal.equals and hashCode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     </parent>
     <groupId>org.jboss</groupId>
     <artifactId>jandex</artifactId>
-    <version>2.3.0.Final</version>
+    <version>2.3.1.Final-SNAPSHOT</version>
     <name>Java Annotation Indexer</name>
     <packaging>bundle</packaging>
 

--- a/src/main/java/org/jboss/jandex/MethodInternal.java
+++ b/src/main/java/org/jboss/jandex/MethodInternal.java
@@ -143,6 +143,9 @@ final class MethodInternal {
         if (!returnType.equals(methodInternal.returnType)) {
             return false;
         }
+        if (defaultValue != null ? !defaultValue.equals(methodInternal.defaultValue) : methodInternal.defaultValue != null) {
+            return false;
+        }
         return Arrays.equals(typeParameters, methodInternal.typeParameters);
     }
 
@@ -157,6 +160,7 @@ final class MethodInternal {
         result = 31 * result + Arrays.hashCode(typeParameters);
         result = 31 * result + Arrays.hashCode(annotations);
         result = 31 * result + (int) flags;
+        result = 31 * result + (defaultValue != null ? defaultValue.hashCode() : 0);
         return result;
     }
 


### PR DESCRIPTION
Backport of #127 to the 2.3 branch, in case we want to do 2.3.1.