### PR TITLE
Read RuntimeInvisible*Annotations in Indexer

### DIFF
--- a/core/src/main/java/org/jboss/jandex/AnnotationInstance.java
+++ b/core/src/main/java/org/jboss/jandex/AnnotationInstance.java
@@ -54,11 +54,7 @@ public final class AnnotationInstance {
         }
     }
 
-    AnnotationInstance(AnnotationInstance instance, AnnotationTarget target) {
-        this(instance.name, target, instance.values, instance.runtimeVisible);
-    }
-
-    AnnotationInstance(DotName name, AnnotationTarget target, AnnotationValue[] values, boolean runtimeVisible) {
+    private AnnotationInstance(DotName name, AnnotationTarget target, AnnotationValue[] values, boolean runtimeVisible) {
         this.name = name;
         this.target = target;
         this.values = values != null && values.length > 0 ? values : AnnotationValue.EMPTY_VALUE_ARRAY;
@@ -66,22 +62,19 @@ public final class AnnotationInstance {
     }
 
     static AnnotationInstance create(AnnotationInstance instance, AnnotationTarget target) {
-        return new AnnotationInstance(instance, target);
-    }
-
-    private static final AnnotationInstance create(DotName name) {
-        return new AnnotationInstance(name, null, AnnotationValue.EMPTY_VALUE_ARRAY, false);
+        return new AnnotationInstance(instance.name, target, instance.values, instance.runtimeVisible);
     }
 
     /**
      * Construct a new mock annotation instance. The passed values array will be defensively copied.
+     * It is assumed that the annotation is {@link #runtimeVisible()}.
      *
      * @param name the name of the annotation instance
      * @param target the thing the annotation is declared on
      * @param values the values of this annotation instance
      * @return the new mock Annotation Instance
      */
-    public static final AnnotationInstance create(DotName name, AnnotationTarget target, AnnotationValue[] values) {
+    public static AnnotationInstance create(DotName name, AnnotationTarget target, AnnotationValue[] values) {
         return create(name, true, target, values);
     }
 
@@ -94,7 +87,7 @@ public final class AnnotationInstance {
      * @param values the values of this annotation instance
      * @return the new mock Annotation Instance
      */
-    public static final AnnotationInstance create(DotName name, boolean visible, AnnotationTarget target,
+    public static AnnotationInstance create(DotName name, boolean visible, AnnotationTarget target,
             AnnotationValue[] values) {
         if (name == null)
             throw new IllegalArgumentException("Name can't be null");
@@ -116,13 +109,14 @@ public final class AnnotationInstance {
 
     /**
      * Construct a new mock annotation instance. The passed values list will be defensively copied.
+     * It is assumed that the annotation is {@link #runtimeVisible()}.
      *
      * @param name the name of the annotation instance
      * @param target the thing the annotation is declared on
      * @param values the values of this annotation instance
      * @return the new mock Annotation Instance
      */
-    public static final AnnotationInstance create(DotName name, AnnotationTarget target, List<AnnotationValue> values) {
+    public static AnnotationInstance create(DotName name, AnnotationTarget target, List<AnnotationValue> values) {
         return create(name, true, target, values);
     }
 
@@ -135,7 +129,7 @@ public final class AnnotationInstance {
      * @param values the values of this annotation instance
      * @return the new mock Annotation Instance
      */
-    public static final AnnotationInstance create(DotName name, boolean visible, AnnotationTarget target,
+    public static AnnotationInstance create(DotName name, boolean visible, AnnotationTarget target,
             List<AnnotationValue> values) {
         if (name == null)
             throw new IllegalArgumentException("Name can't be null");
@@ -146,8 +140,9 @@ public final class AnnotationInstance {
         return create(name, visible, target, values.toArray(ANNOTATION_VALUES_TYPE));
     }
 
-    static final AnnotationInstance binarySearch(AnnotationInstance[] annotations, DotName name) {
-        AnnotationInstance key = create(name);
+    static AnnotationInstance binarySearch(AnnotationInstance[] annotations, DotName name) {
+        // only `name` is significant in `key`, the rest can be arbitrary
+        AnnotationInstance key = new AnnotationInstance(name, null, null, false);
         int i = Arrays.binarySearch(annotations, key, AnnotationInstance.NAME_COMPARATOR);
         return i >= 0 ? annotations[i] : null;
     }
@@ -372,6 +367,9 @@ public final class AnnotationInstance {
 
         this.target = target;
     }
+
+    // runtime visibility is ignored for the purpose of equality and hash code, because
+    // the annotation type identity (the name) already includes that information
 
     /**
      * Returns whether or not this annotation instance is equivalent to another instance.

--- a/core/src/main/java/org/jboss/jandex/FieldInternal.java
+++ b/core/src/main/java/org/jboss/jandex/FieldInternal.java
@@ -123,9 +123,7 @@ final class FieldInternal {
     }
 
     final AnnotationInstance annotation(DotName name) {
-        AnnotationInstance key = new AnnotationInstance(name, null, null);
-        int i = Arrays.binarySearch(annotations, key, AnnotationInstance.NAME_COMPARATOR);
-        return i >= 0 ? annotations[i] : null;
+        return AnnotationInstance.binarySearch(annotations, name);
     }
 
     final boolean hasAnnotation(DotName name) {

--- a/core/src/main/java/org/jboss/jandex/Index.java
+++ b/core/src/main/java/org/jboss/jandex/Index.java
@@ -201,8 +201,7 @@ public final class Index implements IndexView {
         for (AnnotationInstance containingInstance : getAnnotations(containingAnnotationName)) {
             for (AnnotationInstance nestedInstance : containingInstance.value().asNestedArray()) {
                 // We need to set the target of the containing instance
-                instances.add(new AnnotationInstance(nestedInstance.name(), containingInstance.target(),
-                        nestedInstance.valueArray()));
+                instances.add(AnnotationInstance.create(nestedInstance, containingInstance.target()));
             }
         }
         return instances;

--- a/core/src/main/java/org/jboss/jandex/IndexReader.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReader.java
@@ -73,15 +73,15 @@ public final class IndexReader {
             readVersion();
         }
 
-        return reader.read(version);
+        return reader.read();
     }
 
     private void initReader(int version) throws IOException {
         IndexReaderImpl reader;
         if (version >= IndexReaderV1.MIN_VERSION && version <= IndexReaderV1.MAX_VERSION) {
-            reader = new IndexReaderV1(input);
+            reader = new IndexReaderV1(input, version);
         } else if (version >= IndexReaderV2.MIN_VERSION && version <= IndexReaderV2.MAX_VERSION) {
-            reader = new IndexReaderV2(input);
+            reader = new IndexReaderV2(input, version);
         } else {
             input.close();
             throw new UnsupportedVersion("Can't read index version " + version

--- a/core/src/main/java/org/jboss/jandex/IndexReaderImpl.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderImpl.java
@@ -25,7 +25,7 @@ import java.io.IOException;
  * @author Jason T. Greene
  */
 abstract class IndexReaderImpl {
-    abstract Index read(int version) throws IOException;
+    abstract Index read() throws IOException;
 
     abstract int toDataVersion(int version);
 }

--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -318,7 +318,10 @@ final class IndexReaderV2 extends IndexReaderImpl {
         DotName name = nameTable[stream.readPackedU32()];
         AnnotationTarget target = readAnnotationTarget(stream, caller);
         AnnotationValue[] values = readAnnotationValues(stream);
-        boolean visible = (version >= 11) && stream.readBoolean();
+        boolean visible = true;
+        if (version >= 11) {
+            visible = stream.readBoolean();
+        }
         return AnnotationInstance.create(name, visible, target, values);
     }
 

--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -48,7 +48,7 @@ import java.util.Set;
  */
 final class IndexReaderV2 extends IndexReaderImpl {
     static final int MIN_VERSION = 6;
-    static final int MAX_VERSION = 10;
+    static final int MAX_VERSION = 11;
     static final int MAX_DATA_VERSION = 4;
     private static final byte NULL_TARGET_TAG = 0;
     private static final byte FIELD_TAG = 1;
@@ -78,7 +78,8 @@ final class IndexReaderV2 extends IndexReaderImpl {
     private static final int HAS_ENCLOSING_METHOD = 1;
     private final static byte[] INIT_METHOD_NAME = Utils.toUTF8("<init>");
 
-    private PackedDataInputStream input;
+    private final PackedDataInputStream input;
+    private final int version;
     private byte[][] byteTable;
     private String[] stringTable;
     private DotName[] nameTable;
@@ -90,11 +91,12 @@ final class IndexReaderV2 extends IndexReaderImpl {
     private RecordComponentInternal[] recordComponentTable;
     private HashMap<DotName, Set<DotName>> users;
 
-    IndexReaderV2(PackedDataInputStream input) {
+    IndexReaderV2(PackedDataInputStream input, int version) {
         this.input = input;
+        this.version = version;
     }
 
-    Index read(int version) throws IOException {
+    Index read() throws IOException {
         try {
             PackedDataInputStream stream = this.input;
             int annotationsSize = stream.readPackedU32();
@@ -119,12 +121,12 @@ final class IndexReaderV2 extends IndexReaderImpl {
             if (version >= 10) {
                 readUsers(stream, usersSize);
             }
-            readMethodTable(stream, version);
+            readMethodTable(stream);
             readFieldTable(stream);
             if (version >= 10) {
                 readRecordComponentTable(stream);
             }
-            return readClasses(stream, annotationsSize, implementorsSize, subclassesSize, version);
+            return readClasses(stream, annotationsSize, implementorsSize, subclassesSize);
         } finally {
             byteTable = null;
             stringTable = null;
@@ -316,7 +318,8 @@ final class IndexReaderV2 extends IndexReaderImpl {
         DotName name = nameTable[stream.readPackedU32()];
         AnnotationTarget target = readAnnotationTarget(stream, caller);
         AnnotationValue[] values = readAnnotationValues(stream);
-        return new AnnotationInstance(name, target, values);
+        boolean visible = (version >= 11) && stream.readBoolean();
+        return AnnotationInstance.create(name, visible, target, values);
     }
 
     private Type[] readTypeListReference(PackedDataInputStream stream) throws IOException {
@@ -450,12 +453,12 @@ final class IndexReaderV2 extends IndexReaderImpl {
         throw new IllegalStateException("Invalid tag: " + tag);
     }
 
-    private void readMethodTable(PackedDataInputStream stream, int version) throws IOException {
+    private void readMethodTable(PackedDataInputStream stream) throws IOException {
         // Null holds the first slot
         int size = stream.readPackedU32() + 1;
         methodTable = new MethodInternal[size];
         for (int i = 1; i < size; i++) {
-            methodTable[i] = readMethodEntry(stream, version);
+            methodTable[i] = readMethodEntry(stream);
         }
 
     }
@@ -478,7 +481,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
         }
     }
 
-    private MethodInternal readMethodEntry(PackedDataInputStream stream, int version) throws IOException {
+    private MethodInternal readMethodEntry(PackedDataInputStream stream) throws IOException {
         byte[] name = byteTable[stream.readPackedU32()];
         short flags = (short) stream.readPackedU32();
         Type[] typeParameters = typeListTable[stream.readPackedU32()];
@@ -538,7 +541,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
     }
 
     private ClassInfo readClassEntry(PackedDataInputStream stream,
-            Map<DotName, List<AnnotationInstance>> masterAnnotations, int version) throws IOException {
+            Map<DotName, List<AnnotationInstance>> masterAnnotations) throws IOException {
         DotName name = nameTable[stream.readPackedU32()];
         short flags = (short) stream.readPackedU32();
         Type superType = typeTable[stream.readPackedU32()];
@@ -564,7 +567,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
         if (hasNesting) {
             enclosingClass = nameTable[stream.readPackedU32()];
             simpleName = stringTable[stream.readPackedU32()];
-            enclosingMethod = hasEnclosingMethod ? readEnclosingMethod(stream, version) : null;
+            enclosingMethod = hasEnclosingMethod ? readEnclosingMethod(stream) : null;
         }
 
         int size = stream.readPackedU32();
@@ -784,7 +787,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
         }
     }
 
-    private ClassInfo.EnclosingMethodInfo readEnclosingMethod(PackedDataInputStream stream, int version) throws IOException {
+    private ClassInfo.EnclosingMethodInfo readEnclosingMethod(PackedDataInputStream stream) throws IOException {
         if (version < 9 && stream.readUnsignedByte() != HAS_ENCLOSING_METHOD) {
             return null;
         }
@@ -797,7 +800,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
     }
 
     private Index readClasses(PackedDataInputStream stream,
-            int annotationsSize, int implementorsSize, int subclassesSize, int version) throws IOException {
+            int annotationsSize, int implementorsSize, int subclassesSize) throws IOException {
         int classesSize = stream.readPackedU32();
         HashMap<DotName, ClassInfo> classes = new HashMap<DotName, ClassInfo>(classesSize);
         HashMap<DotName, List<ClassInfo>> subclasses = new HashMap<DotName, List<ClassInfo>>(subclassesSize);
@@ -806,7 +809,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
                 annotationsSize);
 
         for (int i = 0; i < classesSize; i++) {
-            ClassInfo clazz = readClassEntry(stream, masterAnnotations, version);
+            ClassInfo clazz = readClassEntry(stream, masterAnnotations);
             addClassToMap(subclasses, clazz.superName(), clazz);
             for (Type interfaceType : clazz.interfaceTypeArray()) {
                 addClassToMap(implementors, interfaceType.name(), clazz);
@@ -827,22 +830,21 @@ final class IndexReaderV2 extends IndexReaderImpl {
             users = Collections.emptyMap();
         }
 
-        Map<DotName, ModuleInfo> modules = (version >= 10) ? readModules(stream, masterAnnotations, version)
+        Map<DotName, ModuleInfo> modules = (version >= 10) ? readModules(stream, masterAnnotations)
                 : Collections.<DotName, ModuleInfo> emptyMap();
 
         return new Index(masterAnnotations, subclasses, implementors, classes, modules, users);
     }
 
     private Map<DotName, ModuleInfo> readModules(PackedDataInputStream stream,
-            Map<DotName, List<AnnotationInstance>> masterAnnotations,
-            int version) throws IOException {
+            Map<DotName, List<AnnotationInstance>> masterAnnotations) throws IOException {
 
         int modulesSize = stream.readPackedU32();
         Map<DotName, ModuleInfo> modules = modulesSize > 0 ? new HashMap<DotName, ModuleInfo>(modulesSize)
                 : Collections.<DotName, ModuleInfo> emptyMap();
 
         for (int i = 0; i < modulesSize; i++) {
-            ClassInfo clazz = readClassEntry(stream, masterAnnotations, version);
+            ClassInfo clazz = readClassEntry(stream, masterAnnotations);
             ModuleInfo module = readModuleEntry(stream, clazz);
             modules.put(module.name(), module);
         }

--- a/core/src/main/java/org/jboss/jandex/IndexWriter.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriter.java
@@ -99,16 +99,16 @@ public final class IndexWriter {
                     + IndexWriterV2.MIN_VERSION + "-" + IndexWriterV2.MAX_VERSION);
         }
 
-        return writer.write(index, version);
+        return writer.write(index);
     }
 
     private IndexWriterImpl getWriter(int version) {
         if (version >= IndexWriterV1.MIN_VERSION && version <= IndexWriterV1.MAX_VERSION) {
-            return new IndexWriterV1(out);
+            return new IndexWriterV1(out, version);
         }
 
         if (version >= IndexWriterV2.MIN_VERSION && version <= IndexWriterV2.MAX_VERSION) {
-            return new IndexWriterV2(out);
+            return new IndexWriterV2(out, version);
         }
 
         return null;

--- a/core/src/main/java/org/jboss/jandex/IndexWriterImpl.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriterImpl.java
@@ -23,5 +23,5 @@ import java.io.IOException;
  * @author Jason T. Greene
  */
 abstract class IndexWriterImpl {
-    abstract int write(Index index, int version) throws IOException;
+    abstract int write(Index index) throws IOException;
 }

--- a/core/src/main/java/org/jboss/jandex/IndexWriterV1.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriterV1.java
@@ -73,6 +73,7 @@ final class IndexWriterV1 extends IndexWriterImpl {
     private static final int AVALUE_NESTED = 13;
 
     private final OutputStream out;
+    private final int version;
     private StrongInternPool<String> pool;
     StrongInternPool<String>.Index poolIndex;
     private TreeMap<DotName, Integer> classTable;
@@ -82,8 +83,9 @@ final class IndexWriterV1 extends IndexWriterImpl {
      *
      * @param out a stream to write an index to
      */
-    IndexWriterV1(OutputStream out) {
+    IndexWriterV1(OutputStream out, int version) {
         this.out = out;
+        this.version = version;
     }
 
     /**
@@ -95,7 +97,7 @@ final class IndexWriterV1 extends IndexWriterImpl {
      * @return the number of bytes written to the stream
      * @throws java.io.IOException if any i/o error occurs
      */
-    int write(Index index, int version) throws IOException {
+    int write(Index index) throws IOException {
 
         if (version < MIN_VERSION || version > MAX_VERSION) {
             throw new UnsupportedVersion("Can't write index version " + version
@@ -110,7 +112,7 @@ final class IndexWriterV1 extends IndexWriterImpl {
         buildTables(index);
         writeClassTable(stream);
         writeStringTable(stream);
-        writeClasses(stream, index, version);
+        writeClasses(stream, index);
         stream.flush();
         return stream.size();
     }
@@ -161,7 +163,7 @@ final class IndexWriterV1 extends IndexWriterImpl {
         return i.intValue();
     }
 
-    private void writeClasses(PackedDataOutputStream stream, Index index, int version) throws IOException {
+    private void writeClasses(PackedDataOutputStream stream, Index index) throws IOException {
         Collection<ClassInfo> classes = index.getKnownClasses();
         stream.writePackedU32(classes.size());
         for (ClassInfo clazz : classes) {

--- a/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -770,7 +770,8 @@ final class IndexWriterV2 extends IndexWriterImpl {
         }
     }
 
-    private void writeAnnotations(PackedDataOutputStream stream, Collection<AnnotationInstance> annotations) throws IOException {
+    private void writeAnnotations(PackedDataOutputStream stream, Collection<AnnotationInstance> annotations)
+            throws IOException {
         if (annotations.isEmpty()) {
             writeAnnotations(stream, AnnotationInstance.EMPTY_ARRAY);
         } else {

--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -443,7 +443,8 @@ public final class Indexer {
             byte annotationAttribute = constantPoolAnnoAttrributes[index - 1];
             if (annotationAttribute == HAS_RUNTIME_ANNOTATION || annotationAttribute == HAS_RUNTIME_INVISIBLE_ANNOTATION) {
                 processAnnotations(data, target, annotationAttribute == HAS_RUNTIME_ANNOTATION);
-            } else if (annotationAttribute == HAS_RUNTIME_PARAM_ANNOTATION || annotationAttribute == HAS_RUNTIME_INVISIBLE_PARAM_ANNOTATION) {
+            } else if (annotationAttribute == HAS_RUNTIME_PARAM_ANNOTATION
+                    || annotationAttribute == HAS_RUNTIME_INVISIBLE_PARAM_ANNOTATION) {
                 if (!(target instanceof MethodInfo)) {
                     if (annotationAttribute == HAS_RUNTIME_PARAM_ANNOTATION) {
                         throw new IllegalStateException("RuntimeVisibleParameterAnnotations appeared on a non-method");
@@ -453,9 +454,11 @@ public final class Indexer {
                 }
                 int numParameters = data.readUnsignedByte();
                 for (short p = 0; p < numParameters; p++) {
-                    processAnnotations(data, new MethodParameterInfo((MethodInfo) target, p), annotationAttribute == HAS_RUNTIME_PARAM_ANNOTATION);
+                    processAnnotations(data, new MethodParameterInfo((MethodInfo) target, p),
+                            annotationAttribute == HAS_RUNTIME_PARAM_ANNOTATION);
                 }
-            } else if (annotationAttribute == HAS_RUNTIME_TYPE_ANNOTATION || annotationAttribute == HAS_RUNTIME_INVISIBLE_TYPE_ANNOTATION) {
+            } else if (annotationAttribute == HAS_RUNTIME_TYPE_ANNOTATION
+                    || annotationAttribute == HAS_RUNTIME_INVISIBLE_TYPE_ANNOTATION) {
                 processTypeAnnotations(data, target, annotationAttribute == HAS_RUNTIME_TYPE_ANNOTATION);
             } else if (annotationAttribute == HAS_SIGNATURE) {
                 processSignature(data, target);
@@ -1958,7 +1961,7 @@ public final class Indexer {
                         annoAttributes[pos] = HAS_RUNTIME_INVISIBLE_PARAM_ANNOTATION;
                     } else if (len == RUNTIME_INVISIBLE_TYPE_ANNOTATIONS_LEN
                             && match(buf, offset, RUNTIME_INVISIBLE_TYPE_ANNOTATIONS)) {
-                        annoAttributes[pos] = HAS_RECORD;
+                        annoAttributes[pos] = HAS_RUNTIME_INVISIBLE_TYPE_ANNOTATION;
                     }
                     offset += len;
                     break;

--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -1065,7 +1065,7 @@ public final class Indexer {
         PathElementStack elements = typeAnnotationState.pathElements;
         PathElement element = elements.pop();
         if (element == null) {
-            type = intern(type.addAnnotation(new AnnotationInstance(typeAnnotationState.annotation, null)));
+            type = intern(type.addAnnotation(AnnotationInstance.create(typeAnnotationState.annotation, null)));
             typeAnnotationState.target.setTarget(type); // FIXME
             // Clone the instance with a null target so that it can be interned
             return type;

--- a/core/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -321,7 +321,7 @@ public final class MethodInfo implements AnnotationTarget {
             Type containingType = repeatable.value().asClass();
             for (AnnotationInstance container : annotations(containingType.name())) {
                 for (AnnotationInstance nestedInstance : container.value().asNestedArray()) {
-                    instances.add(new AnnotationInstance(nestedInstance, container.target()));
+                    instances.add(AnnotationInstance.create(nestedInstance, container.target()));
                 }
             }
         }

--- a/core/src/main/java/org/jboss/jandex/MethodInternal.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInternal.java
@@ -235,9 +235,7 @@ final class MethodInternal {
     }
 
     final AnnotationInstance annotation(DotName name) {
-        AnnotationInstance key = new AnnotationInstance(name, null, null);
-        int i = Arrays.binarySearch(annotations, key, AnnotationInstance.NAME_COMPARATOR);
-        return i >= 0 ? annotations[i] : null;
+        return AnnotationInstance.binarySearch(annotations, name);
     }
 
     final boolean hasAnnotation(DotName name) {

--- a/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
+++ b/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
@@ -114,9 +114,7 @@ final class RecordComponentInternal {
     }
 
     final AnnotationInstance annotation(DotName name) {
-        AnnotationInstance key = new AnnotationInstance(name, null, null);
-        int i = Arrays.binarySearch(annotations, key, AnnotationInstance.NAME_COMPARATOR);
-        return i >= 0 ? annotations[i] : null;
+        return AnnotationInstance.binarySearch(annotations, name);
     }
 
     final boolean hasAnnotation(DotName name) {

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -378,9 +378,7 @@ public abstract class Type {
     }
 
     public final AnnotationInstance annotation(DotName name) {
-        AnnotationInstance key = new AnnotationInstance(name, null, null);
-        int i = Arrays.binarySearch(annotations, key, AnnotationInstance.NAME_COMPARATOR);
-        return i >= 0 ? annotations[i] : null;
+        return AnnotationInstance.binarySearch(annotations, name);
     }
 
     public final boolean hasAnnotation(DotName name) {

--- a/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -475,7 +475,7 @@ public class BasicTestCase {
     }
 
     @Test
-    public void testRuntimeInvisibleAnnotations() throws IOException {
+    public void testRuntimeInvisiblePresentInV11() throws IOException {
         @RuntimeInvisible(placement = "class")
         class Target {
             @SuppressWarnings("unused")
@@ -483,12 +483,43 @@ public class BasicTestCase {
             }
         }
 
-        Index index = Index.of(Target.class);
-        DotName annoName = DotName.createSimple(RuntimeInvisible.class.getName());
-        List<AnnotationInstance> rtInvisible = index.getAnnotations(annoName);
-        assertEquals(2, rtInvisible.size());
         assertEquals(0, Target.class.getDeclaredAnnotations().length);
         assertEquals(0, Target.class.getDeclaredMethods()[0].getDeclaredAnnotations().length);
+
+        Index index = testClassConstantSerialisation(Index.of(Target.class), 11);
+        DotName annoName = DotName.createSimple(RuntimeInvisible.class.getName());
+        List<AnnotationInstance> rtInvisible = index.getAnnotations(annoName);
+
+        assertEquals(2, rtInvisible.size());
+
+        for (AnnotationInstance a : rtInvisible) {
+            assertFalse(a.runtimeVisible());
+        }
+    }
+
+    @Test
+    public void testRuntimeInvisibleAbsentFromV10() throws IOException {
+        @RuntimeInvisible(placement = "class")
+        class Target {
+            @SuppressWarnings("unused")
+            @MethodAnnotation1
+            void execute(@RuntimeInvisible(placement = "arg") String arg) {
+            }
+        }
+
+        Index index = testClassConstantSerialisation(Index.of(Target.class), 10);
+        DotName annoName = DotName.createSimple(RuntimeInvisible.class.getName());
+        List<AnnotationInstance> rtInvisible = index.getAnnotations(annoName);
+
+        assertEquals(0, rtInvisible.size());
+
+        annoName = DotName.createSimple(MethodAnnotation1.class.getName());
+        List<AnnotationInstance> rtVisible = index.getAnnotations(annoName);
+        assertEquals(1, rtVisible.size());
+
+        for (AnnotationInstance a : rtVisible) {
+            assertTrue(a.runtimeVisible());
+        }
     }
 
     private void verifyDummy(Index index, boolean v2features) {

--- a/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -122,6 +122,12 @@ public class BasicTestCase {
         float value();
     }
 
+    @Retention(RetentionPolicy.CLASS)
+    @Target({ ElementType.TYPE, ElementType.PARAMETER })
+    @interface RuntimeInvisible {
+        String placement();
+    }
+
     // @formatter:off
     @TestAnnotation(name = "Test", override = "somethingelse", ints = { 1, 2, 3, 4, 5 }, klass = Void.class,
             nested = @NestedAnnotation(1.34f), nestedArray = { @NestedAnnotation(3.14f), @NestedAnnotation(2.27f) },
@@ -466,6 +472,23 @@ public class BasicTestCase {
     public void testNullClass() throws IOException {
         Indexer indexer = new Indexer();
         indexer.indexClass(null);
+    }
+
+    @Test
+    public void testRuntimeInvisibleAnnotations() throws IOException {
+        @RuntimeInvisible(placement = "class")
+        class Target {
+            @SuppressWarnings("unused")
+            void execute(@RuntimeInvisible(placement = "arg") String arg) {
+            }
+        }
+
+        Index index = Index.of(Target.class);
+        DotName annoName = DotName.createSimple(RuntimeInvisible.class.getName());
+        List<AnnotationInstance> rtInvisible = index.getAnnotations(annoName);
+        assertEquals(2, rtInvisible.size());
+        assertEquals(0, Target.class.getDeclaredAnnotations().length);
+        assertEquals(0, Target.class.getDeclaredMethods()[0].getDeclaredAnnotations().length);
     }
 
     private void verifyDummy(Index index, boolean v2features) {


### PR DESCRIPTION
Fixes #120 - I'm hoping they were not excluded deliberately originally :-) This also includes a refactoring of `processAttributes` to use a switch statement for readability.