### PR TITLE
Use Locale.ROOT in String.format()

### DIFF
--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -33,6 +33,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import static org.jboss.jandex.ClassInfo.EnclosingMethodInfo;
@@ -1631,7 +1632,7 @@ public final class Indexer {
         int pos = offsets[index - 1];
 
         if (pool[pos] != constantType) {
-            throw new IllegalStateException(String.format("Constant pool entry is not a %s type: %d:%d", typeName, index, pos));
+            throw new IllegalStateException(String.format(Locale.ROOT, "Constant pool entry is not a %s type: %d:%d", typeName, index, pos));
         }
 
         int nameIndex = (pool[++pos] & 0xFF) << 8 | (pool[++pos] & 0xFF);
@@ -1902,7 +1903,7 @@ public final class Indexer {
                     break;
                default:
                    throw new IllegalStateException(
-                           String.format("Unknown tag %s! pos = %s poolCount = %s", tag, pos, poolCount));
+                           String.format(Locale.ROOT, "Unknown tag %s! pos = %s poolCount = %s", tag, pos, poolCount));
             }
         }
 

--- a/src/main/java/org/jboss/jandex/Main.java
+++ b/src/main/java/org/jboss/jandex/Main.java
@@ -23,6 +23,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Locale;
 
 /**
  * Responsible for launching the indexing tool on a java command line.
@@ -87,7 +88,7 @@ public class Main {
         Result result = (source.isDirectory()) ? indexDirectory(source, indexer) : JarIndexer.createJarIndex(source, indexer, outputFile, modify, jarFile, verbose);
 
         double time = (System.currentTimeMillis() - start) / 1000.00;
-        System.out.printf("Wrote %s in %.4f seconds (%d classes, %d annotations, %d instances, %d class usages, %d bytes)\n", result.getName(), time, result.getClasses(), result.getAnnotations(), result.getInstances(), result.getUsages(), result.getBytes());
+        System.out.printf(Locale.ROOT, "Wrote %s in %.4f seconds (%d classes, %d annotations, %d instances, %d class usages, %d bytes)%n", result.getName(), time, result.getClasses(), result.getAnnotations(), result.getInstances(), result.getUsages(), result.getBytes());
         return result.getIndex();
     }
 
@@ -102,7 +103,7 @@ public class Main {
         index.printAnnotations();
         index.printSubclasses();
 
-        System.out.printf("\nRead %s in %.04f seconds\n", source.getName(), end / 1000.0);
+        System.out.printf(Locale.ROOT, "%nRead %s in %.04f seconds%n", source.getName(), end / 1000.0);
     }
 
     private Result indexDirectory(File source, Indexer indexer) throws FileNotFoundException, IOException {

--- a/src/test/java/org/jboss/jandex/test/ClassInfoMemberPositionTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/ClassInfoMemberPositionTestCase.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Locale;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
@@ -94,12 +95,12 @@ public class ClassInfoMemberPositionTestCase {
 
         List<FieldInfo> unsortedFields = clazz.unsortedFields();
         for (int i = 0; i < 256; i++) {
-            assertEquals(String.format("f%03d", 255 - i), unsortedFields.get(i).name());
+            assertEquals(String.format(Locale.ROOT, "f%03d", 255 - i), unsortedFields.get(i).name());
         }
 
         List<FieldInfo> sortedFields = clazz.fields();
         for (int i = 0; i < 256; i++) {
-            assertEquals(String.format("f%03d", i), sortedFields.get(i).name());
+            assertEquals(String.format(Locale.ROOT, "f%03d", i), sortedFields.get(i).name());
         }
     }
 
@@ -110,12 +111,12 @@ public class ClassInfoMemberPositionTestCase {
 
         List<FieldInfo> unsortedFields = clazz.unsortedFields();
         for (int i = 0; i < 257; i++) {
-            assertEquals(String.format("f%03d", i), unsortedFields.get(i).name());
+            assertEquals(String.format(Locale.ROOT, "f%03d", i), unsortedFields.get(i).name());
         }
 
         List<FieldInfo> sortedFields = clazz.fields();
         for (int i = 0; i < 257; i++) {
-            assertEquals(String.format("f%03d", i), sortedFields.get(i).name());
+            assertEquals(String.format(Locale.ROOT, "f%03d", i), sortedFields.get(i).name());
         }
     }
 


### PR DESCRIPTION
Is generally a bad practice to depend on the default platform locale, so this PR use Locale.ROOT for [String.format()](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#format-java.util.Locale-java.lang.String-java.lang.Object...-) calls.