### PR TITLE
Add support for strings longer than 64 kB

### DIFF
--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -19,6 +19,7 @@
 package org.jboss.jandex;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -169,7 +170,14 @@ final class IndexReaderV2 extends IndexReaderImpl {
         int size = stream.readPackedU32() + 1;
         String[] stringTable = this.stringTable = new String[size];
         for (int i = 1; i < size; i++) {
-            stringTable[i] = stream.readUTF();
+            if (version >= 11) {
+                int len = stream.readPackedU32();
+                byte[] bytes = new byte[len];
+                stream.readFully(bytes, 0, len);
+                stringTable[i] = new String(bytes, StandardCharsets.UTF_8);
+            } else {
+                stringTable[i] = stream.readUTF();
+            }
         }
     }
 

--- a/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -21,6 +21,7 @@ package org.jboss.jandex;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -243,7 +244,13 @@ final class IndexWriterV2 extends IndexWriterImpl {
         Iterator<String> iterator = stringPool.iterator();
         while (iterator.hasNext()) {
             String string = iterator.next();
-            stream.writeUTF(string);
+            if (version >= 11) {
+                byte[] bytes = string.getBytes(StandardCharsets.UTF_8);
+                stream.writePackedU32(bytes.length);
+                stream.write(bytes);
+            } else {
+                stream.writeUTF(string);
+            }
         }
     }
 


### PR DESCRIPTION
The `Data{Input,Output}Stream` classes only support [de]serializing
strings up to 64 kB of length, because they store/expect the length
of the string as a `short`. Sometimes, we need to read/write
longer strings. This commit does that by not using the built-in
support for strings, but doing a very similar thing manually.

A string is serialized as a number of bytes of an UTF-8 encoding
of the string (using our custom variable-length encoding of numbers),
followed by the byte array of the UTF-8 encoding of the string.
This only applies in a new persistent index format version. Older
versions are still handled using the old encoding.

Note that while `Data{Input,Output}Stream` uses a custom encoding
for strings, called "modified UTF-8", we use UTF-8 directly. For our
purposes, it shouldn't make a difference.

Fixes #49