### PR TITLE
[2.4] Support top-level class name with leading inner class delimiter

### DIFF
--- a/src/main/java/org/jboss/jandex/NameTable.java
+++ b/src/main/java/org/jboss/jandex/NameTable.java
@@ -45,7 +45,7 @@ class NameTable {
         if (result != null)
             return result;
 
-        int loc = lastIndexOf(name, delim, '$');
+        int loc = lastIndexOf(name, delim);
         String local = intern(name.substring(loc + 1));
         DotName prefix = loc < 1 ? null : convertToName(intern(name.substring(0, loc)), delim);
         result = new DotName(prefix, local, true, loc > 0 && name.charAt(loc) == '$');
@@ -55,23 +55,21 @@ class NameTable {
         return result;
     }
 
-    private int lastIndexOf(String name, char delim1, char delim2) {
+    private int lastIndexOf(String name, char delim) {
         // Begin at second last position to avoid empty local name
         int pos = name.length() - 1;
         while (--pos >= 0) {
             char c = name.charAt(pos);
-
-            if (c == delim1) {
+            if (c == delim || c == '$') {
                 break;
             }
+        }
 
-            /*
-             * Only split on the inner class delimiter when it will not
-             * result in an empty string for the containing top-level class.
-             */
-            if (c == delim2 && pos > 0 && name.charAt(pos - 1) != delim1) {
-                break;
-            }
+        // avoid splitting on '$' if previous char is a delimiter or the '$'
+        // is in position 0, because subsequent split would produce an empty
+        // local name
+        if (pos >=0 && name.charAt(pos) == '$' && (pos == 0 || name.charAt(pos - 1) == delim)) {
+            pos--;
         }
 
         return pos;

--- a/src/main/java/org/jboss/jandex/NameTable.java
+++ b/src/main/java/org/jboss/jandex/NameTable.java
@@ -60,7 +60,16 @@ class NameTable {
         int pos = name.length() - 1;
         while (--pos >= 0) {
             char c = name.charAt(pos);
-            if (c == delim1 || c == delim2) {
+
+            if (c == delim1) {
+                break;
+            }
+
+            /*
+             * Only split on the inner class delimiter when it will not
+             * result in an empty string for the containing top-level class.
+             */
+            if (c == delim2 && pos > 0 && name.charAt(pos - 1) != delim1) {
                 break;
             }
         }

--- a/src/test/java/$delimiters$/test/$SurroundedByDelimiters$.java
+++ b/src/test/java/$delimiters$/test/$SurroundedByDelimiters$.java
@@ -1,0 +1,5 @@
+package $delimiters$.test;
+
+public class $SurroundedByDelimiters$ {
+
+}

--- a/src/test/java/$pkg/test/$LeadingDelimiter.java
+++ b/src/test/java/$pkg/test/$LeadingDelimiter.java
@@ -1,0 +1,5 @@
+package $pkg.test;
+
+public class $LeadingDelimiter {
+
+}

--- a/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
@@ -237,14 +237,29 @@ public class DotNameTestCase {
 
     @Test
     public void testLeadingInnerClassDelimiterOnClass() throws IOException {
-        DotName $pkg = DotName.createComponentized(null, "$pkg");
-        DotName test = DotName.createComponentized($pkg, "test");
+        DotName pkg = DotName.createComponentized(null, "$pkg");
+        DotName test = DotName.createComponentized(pkg, "test");
         DotName testName = DotName.createComponentized(test, $LeadingDelimiter.class.getSimpleName());
 
         Index index = Index.of($LeadingDelimiter.class);
         assertEquals(testName, index.getKnownClasses().iterator().next().name());
         assertNotNull(index.getClassByName(DotName.createSimple($LeadingDelimiter.class.getName())));
         assertNotNull(index.getClassByName(testName));
+    }
+
+    @Test
+    public void testClassNameWithDelimitersFirstAndLast() throws IOException {
+        DotName pkg = DotName.createComponentized(null, "$delimiters$");
+        DotName test = DotName.createComponentized(pkg, "test");
+        DotName testName = DotName.createComponentized(test, $delimiters$.test.$SurroundedByDelimiters$.class.getSimpleName());
+        DotName testNameSimple = DotName.createSimple($delimiters$.test.$SurroundedByDelimiters$.class.getName());
+
+        Index index = Index.of($delimiters$.test.$SurroundedByDelimiters$.class);
+        DotName indexedName = index.getKnownClasses().iterator().next().name();
+        assertEquals(testName, indexedName);
+        assertNotNull(index.getClassByName(testNameSimple));
+        assertNotNull(index.getClassByName(testName));
+        assertEquals("$delimiters$.test.$SurroundedByDelimiters$", indexedName.toString());
     }
 
     private static DotName createRandomDotName() {

--- a/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
+++ b/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
@@ -20,8 +20,8 @@ package org.jboss.jandex.test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -32,6 +32,8 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.junit.Assert;
 import org.junit.Test;
+
+import $pkg.test.$LeadingDelimiter;
 
 /**
  * Since DotName is often used as a key in collections and implements Comparable,
@@ -231,6 +233,18 @@ public class DotNameTestCase {
 
     public static class Test$ {
 
+    }
+
+    @Test
+    public void testLeadingInnerClassDelimiterOnClass() throws IOException {
+        DotName $pkg = DotName.createComponentized(null, "$pkg");
+        DotName test = DotName.createComponentized($pkg, "test");
+        DotName testName = DotName.createComponentized(test, $LeadingDelimiter.class.getSimpleName());
+
+        Index index = Index.of($LeadingDelimiter.class);
+        assertEquals(testName, index.getKnownClasses().iterator().next().name());
+        assertNotNull(index.getClassByName(DotName.createSimple($LeadingDelimiter.class.getName())));
+        assertNotNull(index.getClassByName(testName));
     }
 
     private static DotName createRandomDotName() {


### PR DESCRIPTION
Fixes #148 

Prior to #130 , top-level classes with names leading with `$` were parsed as nested classes contained within an empty-name class. Classes could still be retrieved from the index by simple `DotName`s as they were still equal via the `DotName#crossEquals` method.

If this is accepted I can open a separate PR for the `smallrye` branch.