### PR TITLE
Fix decoding UTF-8 constant pool entries

### DIFF
--- a/core/src/test/java/org/jboss/jandex/test/Utf8ConstantEncodingTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/Utf8ConstantEncodingTest.java
@@ -1,0 +1,83 @@
+package org.jboss.jandex.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.junit.Test;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.ClassFileVersion;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.description.annotation.AnnotationDescription;
+import net.bytebuddy.description.type.TypeDescription;
+
+public class Utf8ConstantEncodingTest {
+    @interface MyAnnotation {
+        String value();
+    }
+
+    private static final String CLASS_NAME = "org.jboss.jandex.test.MyTestClass";
+
+    private static final String LONG_STRING;
+
+    static {
+        // in UTF-8, the null character is encoded as 0x00, while in "modified UTF-8" per `DataInput`,
+        // it is encoded as 0xC0 0x80 (this is not the only difference between the two encodings,
+        // but is the easiest to test with)
+        StringBuilder longString = new StringBuilder();
+        for (int i = 0; i < 25_000; i++) {
+            longString.append('\0');
+        }
+        LONG_STRING = longString.toString();
+    }
+
+    @Test
+    public void test() throws IOException {
+        byte[] clazz = new ByteBuddy()
+                .with(ClassFileVersion.JAVA_V8)
+                .with(new NamingStrategy.AbstractBase() {
+                    @Override
+                    protected String name(TypeDescription superClass) {
+                        return CLASS_NAME;
+                    }
+                })
+                .subclass(Object.class)
+                .annotateType(AnnotationDescription.Builder.ofType(MyAnnotation.class)
+                        .define("value", LONG_STRING)
+                        .build())
+                .make()
+                .getBytes();
+
+        Indexer indexer = new Indexer();
+        indexer.indexClass(MyAnnotation.class);
+        indexer.index(new ByteArrayInputStream(clazz));
+        Index index = indexer.complete();
+
+        verifyAnnotationValue(index);
+
+        Index index2 = roundtrip(index);
+
+        verifyAnnotationValue(index2);
+    }
+
+    private void verifyAnnotationValue(Index index) {
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(CLASS_NAME));
+        String annotationValue = clazz.classAnnotation(DotName.createSimple(MyAnnotation.class.getName())).value().asString();
+        assertEquals(LONG_STRING, annotationValue);
+    }
+
+    private Index roundtrip(Index index) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new IndexWriter(baos).write(index);
+        return new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+    }
+}


### PR DESCRIPTION
Constant pool entries of type `CONSTANT_Utf8_info` do not, despite
the name, use the UTF-8 encoding. They use a modified variant
of UTF-8, as specified by `java.io.Data{Input,Output}`.

When decoding these entries, the `Indexer.decodeUtf8Entry` method
interpreted the data as UTF-8. This didn't cause issues, because
the constants are usually human-readable strings that fit the ASCII
table, in which case the two encodings do not differ.

In case of machine-generated content, the difference may easily
occur; for example in case of a string that contains the null
character. One realistic example is the Kotlin standard library
JAR, where the `kotlin/collections/ArraysKt___ArraysKt.class` class
contains a `@KotlinMetadata` annotation whose `d1` member contains
such "weird" string.

The fix is simple: use `DataInputStream` to read a `String` out of
the byte array.

Fixes #49