### PR TITLE
[2.4] Fix decoding UTF-8 constant pool entries

### DIFF
--- a/src/main/java/org/jboss/jandex/Indexer.java
+++ b/src/main/java/org/jboss/jandex/Indexer.java
@@ -19,12 +19,12 @@
 package org.jboss.jandex;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Modifier;
-import java.nio.charset.Charset;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -816,7 +816,7 @@ public final class Indexer {
         }
     }
 
-    private void resolveUsers() {
+    private void resolveUsers() throws IOException {
         byte[] pool = constantPool;
         int[] offsets = constantPoolOffsets;
 
@@ -1613,19 +1613,19 @@ public final class Indexer {
 
     }
 
-    private DotName decodeClassEntry(int index) {
+    private DotName decodeClassEntry(int index) throws IOException {
         return index == 0 ? null : decodeDotNameEntry(index, CONSTANT_CLASS, "Class_info", '/');
     }
 
-    private DotName decodeModuleEntry(int index) {
+    private DotName decodeModuleEntry(int index) throws IOException {
         return index == 0 ? null : decodeDotNameEntry(index, CONSTANT_MODULE, "Module_info", '.');
     }
 
-    private DotName decodePackageEntry(int index) {
+    private DotName decodePackageEntry(int index) throws IOException {
         return index == 0 ? null : decodeDotNameEntry(index, CONSTANT_PACKAGE, "Package_info", '/');
     }
 
-    private DotName decodeDotNameEntry(int index, int constantType, String typeName, char delim) {
+    private DotName decodeDotNameEntry(int index, int constantType, String typeName, char delim) throws IOException {
         byte[] pool = constantPool;
         int[] offsets = constantPoolOffsets;
 
@@ -1639,11 +1639,11 @@ public final class Indexer {
         return names.convertToName(decodeUtf8Entry(nameIndex), delim);
     }
 
-    private String decodeOptionalUtf8Entry(int index) {
+    private String decodeOptionalUtf8Entry(int index) throws IOException {
         return index == 0 ? null : decodeUtf8Entry(index);
     }
 
-    private String decodeUtf8Entry(int index) {
+    private String decodeUtf8Entry(int index) throws IOException {
         byte[] pool = constantPool;
         int[] offsets = constantPoolOffsets;
 
@@ -1651,8 +1651,11 @@ public final class Indexer {
         if (pool[pos] != CONSTANT_UTF8)
             throw new IllegalStateException("Constant pool entry is not a utf8 info type: " + index + ":" + pos);
 
-        int len = (pool[++pos] & 0xFF) << 8 | (pool[++pos] & 0xFF);
-        return new String(pool, ++pos, len, Charset.forName("UTF-8"));
+        pos++;
+
+        // DataInputStream needs to read the length again
+        int len = (pool[pos] & 0xFF) << 8 | (pool[pos + 1] & 0xFF);
+        return new DataInputStream(new ByteArrayInputStream(pool, pos, len + 2)).readUTF();
     }
 
     private byte[] decodeUtf8EntryAsBytes(int index) {
@@ -1678,7 +1681,7 @@ public final class Indexer {
         }
     }
 
-    private NameAndType decodeNameAndTypeEntry(int index) {
+    private NameAndType decodeNameAndTypeEntry(int index) throws IOException {
         byte[] pool = constantPool;
         int[] offsets = constantPoolOffsets;
 

--- a/src/test/java/org/jboss/jandex/test/Utf8ConstantEncodingTest.java
+++ b/src/test/java/org/jboss/jandex/test/Utf8ConstantEncodingTest.java
@@ -1,0 +1,86 @@
+package org.jboss.jandex.test;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+import org.junit.Test;
+
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.ClassFileVersion;
+import net.bytebuddy.NamingStrategy;
+import net.bytebuddy.description.annotation.AnnotationDescription;
+import net.bytebuddy.description.type.TypeDescription;
+
+public class Utf8ConstantEncodingTest {
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface MyAnnotation {
+        String value();
+    }
+
+    private static final String CLASS_NAME = "org.jboss.jandex.test.MyTestClass";
+
+    private static final String LONG_STRING;
+
+    static {
+        // in UTF-8, the null character is encoded as 0x00, while in "modified UTF-8" per `DataInput`,
+        // it is encoded as 0xC0 0x80 (this is not the only difference between the two encodings,
+        // but is the easiest to test with)
+        StringBuilder longString = new StringBuilder();
+        for (int i = 0; i < 25000; i++) {
+            longString.append('\0');
+        }
+        LONG_STRING = longString.toString();
+    }
+
+    @Test
+    public void test() throws IOException {
+        byte[] clazz = new ByteBuddy()
+                .with(ClassFileVersion.JAVA_V8)
+                .with(new NamingStrategy.AbstractBase() {
+                    @Override
+                    protected String name(TypeDescription superClass) {
+                        return CLASS_NAME;
+                    }
+                })
+                .subclass(Object.class)
+                .annotateType(AnnotationDescription.Builder.ofType(MyAnnotation.class)
+                        .define("value", LONG_STRING)
+                        .build())
+                .make()
+                .getBytes();
+
+        Indexer indexer = new Indexer();
+        indexer.indexClass(MyAnnotation.class);
+        indexer.index(new ByteArrayInputStream(clazz));
+        Index index = indexer.complete();
+
+        verifyAnnotationValue(index);
+
+        Index index2 = roundtrip(index);
+
+        verifyAnnotationValue(index2);
+    }
+
+    private void verifyAnnotationValue(Index index) {
+        ClassInfo clazz = index.getClassByName(DotName.createSimple(CLASS_NAME));
+        String annotationValue = clazz.classAnnotation(DotName.createSimple(MyAnnotation.class.getName())).value().asString();
+        assertEquals(LONG_STRING, annotationValue);
+    }
+
+    private Index roundtrip(Index index) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        new IndexWriter(baos).write(index);
+        return new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+    }
+}


### PR DESCRIPTION
Constant pool entries of type `CONSTANT_Utf8_info` do not, despite
the name, use the UTF-8 encoding. They use a modified variant
of UTF-8, as specified by `java.io.Data{Input,Output}`.

When decoding these entries, the `Indexer.decodeUtf8Entry` method
interpreted the data as UTF-8. This didn't cause issues, because
the constants are usually human-readable strings that fit the ASCII
table, in which case the two encodings do not differ.

In case of machine-generated content, the difference may easily
occur; for example in case of a string that contains the null
character. One realistic example is the Kotlin standard library
JAR, where the `kotlin/collections/ArraysKt___ArraysKt.class` class
contains a `@KotlinMetadata` annotation whose `d1` member contains
such "weird" string.

The fix is simple: use `DataInputStream` to read a `String` out of
the byte array.