### PR TITLE
make Indexer.index() return void

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassSummary.java
+++ b/core/src/main/java/org/jboss/jandex/ClassSummary.java
@@ -1,0 +1,19 @@
+package org.jboss.jandex;
+
+public final class ClassSummary {
+    private final String name;
+    private final int annotationsCount;
+
+    ClassSummary(String name, int annotationsCount) {
+        this.name = name;
+        this.annotationsCount = annotationsCount;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public int annotationsCount() {
+        return annotationsCount;
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -2017,35 +2017,46 @@ public final class Indexer {
 
     /**
      * Analyze and index the class file data present in the passed class.
-     * Each call adds information to the final complete index; however, to aid in
-     * processing a per-class index (ClassInfo) is returned on each call.
+     * Each call adds information to the final complete index.
      *
      * @param clazz a previously-loaded class
-     * @return a class index containing all annotations on the passed class stream
      * @throws IOException if the class file data is corrupt or the underlying stream fails
      * @throws IllegalArgumentException if clazz is null
      */
-    public ClassInfo indexClass(Class<?> clazz) throws IOException {
+    public void indexClass(Class<?> clazz) throws IOException {
         if (clazz == null) {
             throw new IllegalArgumentException("clazz cannot be null");
         }
         String resourceName = '/' + clazz.getName().replace('.', '/') + ".class";
         try (InputStream resource = clazz.getResourceAsStream(resourceName)) {
-            return index(resource);
+            index(resource);
         }
     }
 
     /**
      * Analyze and index the class file data present in the passed input stream.
-     * Each call adds information to the final complete index; however, to aid in
-     * processing a per-class index (ClassInfo) is returned on each call.
+     * Each call adds information to the final complete index.
      *
      * @param stream a stream pointing to class file data
-     * @return a class index containing all annotations on the passed class stream
      * @throws IOException if the class file data is corrupt or the underlying stream fails
      * @throws IllegalArgumentException if stream is null
      */
-    public ClassInfo index(InputStream stream) throws IOException {
+    public void index(InputStream stream) throws IOException {
+        indexWithSummary(stream);
+    }
+
+    /**
+     * Analyze and index the class file data present in the passed input stream.
+     * Each call adds information to the final complete index. For reporting progress
+     * in batch indexers, this variant of {@code index} returns a summary of
+     * the just-indexed class.
+     *
+     * @param stream a stream pointing to class file data
+     * @return a summary of the just-indexed class
+     * @throws IOException if the class file data is corrupt or the underlying stream fails
+     * @throws IllegalArgumentException if stream is null
+     */
+    public ClassSummary indexWithSummary(InputStream stream) throws IOException {
         if (stream == null) {
             throw new IllegalArgumentException("stream cannot be null");
         }
@@ -2083,7 +2094,7 @@ public final class Indexer {
                 currentClass.module().setMainClass(moduleMainClass);
             }
 
-            return currentClass;
+            return new ClassSummary(currentClass.name().toString(), currentClass.annotations().size());
         } finally {
             constantPool = null;
             constantPoolOffsets = null;

--- a/core/src/main/java/org/jboss/jandex/JarIndexer.java
+++ b/core/src/main/java/org/jboss/jandex/JarIndexer.java
@@ -171,9 +171,9 @@ public class JarIndexer {
                 if (entry.getName().endsWith(".class")) {
                     try {
                         final InputStream stream = jar.getInputStream(entry);
-                        ClassInfo info;
+                        ClassSummary info;
                         try {
-                            info = indexer.index(stream);
+                            info = indexer.indexWithSummary(stream);
                         } finally {
                             safeClose(stream);
                         }
@@ -229,8 +229,8 @@ public class JarIndexer {
         }
     }
 
-    private static void printIndexEntryInfo(ClassInfo info, PrintStream infoStream) {
-        infoStream.println("Indexed " + info.name() + " (" + info.annotations().size() + " annotations)");
+    private static void printIndexEntryInfo(ClassSummary info, PrintStream infoStream) {
+        infoStream.println("Indexed " + info.name() + " (" + info.annotationsCount() + " annotations)");
     }
 
     private static void copy(InputStream in, OutputStream out) throws IOException {

--- a/core/src/main/java/org/jboss/jandex/Main.java
+++ b/core/src/main/java/org/jboss/jandex/Main.java
@@ -133,8 +133,8 @@ public class Main {
         }
     }
 
-    private void printIndexEntryInfo(ClassInfo info) {
-        System.out.println("Indexed " + info.name() + " (" + info.annotations().size() + " annotations)");
+    private void printIndexEntryInfo(ClassSummary info) {
+        System.out.println("Indexed " + info.name() + " (" + info.annotationsCount() + " annotations)");
     }
 
     private void scanFile(File source, Indexer indexer) throws FileNotFoundException, IOException {
@@ -155,7 +155,7 @@ public class Main {
         FileInputStream input = new FileInputStream(source);
 
         try {
-            ClassInfo info = indexer.index(input);
+            ClassSummary info = indexer.indexWithSummary(input);
             if (verbose && info != null)
                 printIndexEntryInfo(info);
         } catch (Exception e) {

--- a/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -67,6 +67,7 @@ import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 public class BasicTestCase {
@@ -368,10 +369,7 @@ public class BasicTestCase {
         indexer.index(stream);
         Index index = indexer.complete();
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(index);
-
-        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+        index = IndexingUtil.roundtrip(index);
 
         verifyDummy(index, true);
     }
@@ -384,10 +382,8 @@ public class BasicTestCase {
         indexer.index(stream);
         Index index = indexer.complete();
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(index, (byte) 2);
+        index = IndexingUtil.roundtrip(index);
 
-        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
         assertFalse(index.getClassByName(DotName.createSimple(DummyClass.class.getName())).hasNoArgsConstructor());
     }
 

--- a/core/src/test/java/org/jboss/jandex/test/BridgeMethodTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/BridgeMethodTestCase.java
@@ -33,10 +33,10 @@ import java.util.Set;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
-import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeTarget;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 public class BridgeMethodTestCase {
@@ -112,8 +112,7 @@ public class BridgeMethodTestCase {
             TypeTarget.Usage usage,
             String expectedBridgeType,
             String expectedNonBridgeType) throws IOException {
-        Indexer indexer = new Indexer();
-        ClassInfo info = indexer.index(getClassBytes(klass));
+        ClassInfo info = IndexingUtil.indexSingle(getClassBytes(klass));
         int methods = 0;
         for (MethodInfo method : info.methods()) {
             if (!methodName.equals(method.name())) {
@@ -145,8 +144,7 @@ public class BridgeMethodTestCase {
         DotName nullable = DotName.createSimple("test.Nullable");
         DotName untainted = DotName.createSimple("test.Untainted");
 
-        Indexer indexer = new Indexer();
-        ClassInfo clazz = indexer.index(getClassBytes("test/BridgeMethods$Subclass.class"));
+        ClassInfo clazz = IndexingUtil.indexSingle(getClassBytes("test/BridgeMethods$Subclass.class"));
         for (MethodInfo method : filterMethods(clazz, "typeVariable")) {
             if (method.returnType().name().equals(DotName.createSimple(Collection.class.getName()))) {
                 // bridge method

--- a/core/src/test/java/org/jboss/jandex/test/ClassInfoMemberPositionTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/ClassInfoMemberPositionTestCase.java
@@ -20,22 +20,16 @@ package org.jboss.jandex.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.util.List;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -59,32 +53,8 @@ public class ClassInfoMemberPositionTestCase {
     }
 
     @Test
-    public void testMembersUnsortedWithFile() throws IOException {
-        File tmpIndex = File.createTempFile("cls", ".idx");
-        OutputStream output = null;
-        try {
-            output = new FileOutputStream(tmpIndex);
-            IndexWriter writer = new IndexWriter(output);
-            writer.write(this.index);
-        } finally {
-            if (output != null) {
-                output.close();
-            }
-        }
-
-        InputStream input = null;
-        Index fileIndex;
-        try {
-            input = new FileInputStream(tmpIndex);
-            IndexReader reader = new IndexReader(input);
-            fileIndex = reader.read();
-        } finally {
-            if (input != null) {
-                input.close();
-            }
-        }
-
-        assertOriginalPositions(fileIndex);
+    public void testMembersUnsortedAfterRoundtrip() throws IOException {
+        assertOriginalPositions(IndexingUtil.roundtrip(index));
     }
 
     @Test

--- a/core/src/test/java/org/jboss/jandex/test/ConstantDynamicTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/ConstantDynamicTestCase.java
@@ -2,11 +2,10 @@ package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import java.io.ByteArrayInputStream;
 import java.util.concurrent.Callable;
 
 import org.jboss.jandex.ClassInfo;
-import org.jboss.jandex.Indexer;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 import net.bytebuddy.ByteBuddy;
@@ -19,7 +18,6 @@ public class ConstantDynamicTestCase {
 
     @Test
     public void testConstantDynamicSupport() throws Exception {
-        Indexer indexer = new Indexer();
         // Creating dynamic constants using Byte Buddy
         // Inspired from https://www.javacodegeeks.com/2018/08/hands-on-java-constantdynamic.html
         final byte[] dynamicConstantsClass = new ByteBuddy()
@@ -29,7 +27,7 @@ public class ConstantDynamicTestCase {
                 .intercept(FixedValue.value(JavaConstant.Dynamic.ofInvocation(Object.class.getConstructor())))
                 .make()
                 .getBytes();
-        ClassInfo classInfo = indexer.index(new ByteArrayInputStream(dynamicConstantsClass));
+        ClassInfo classInfo = IndexingUtil.indexSingle(dynamicConstantsClass);
         assertNotNull(classInfo);
     }
 }

--- a/core/src/test/java/org/jboss/jandex/test/InnerClassTypeAnnotationTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/InnerClassTypeAnnotationTestCase.java
@@ -20,17 +20,14 @@ package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 public class InnerClassTypeAnnotationTestCase {
@@ -76,10 +73,7 @@ public class InnerClassTypeAnnotationTestCase {
 
     private void verifyRW(String name, int pos1, int pos2) throws IOException {
         Index index = buildIndex(name);
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(index);
-
-        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+        index = IndexingUtil.roundtrip(index);
 
         verifyTypeAnnotations(index, name, pos1);
         if (pos2 != -1) {

--- a/core/src/test/java/org/jboss/jandex/test/ModifiersTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/ModifiersTestCase.java
@@ -3,13 +3,12 @@ package org.jboss.jandex.test;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.FieldInfo;
-import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 import net.bytebuddy.ByteBuddy;
@@ -31,22 +30,22 @@ public class ModifiersTestCase {
 
     @Test
     public void testClassIsSynthetic() throws Exception {
-        Indexer indexer = new Indexer();
         final byte[] syntheticClass = new ByteBuddy().subclass(Object.class)
-                .visit(new ModifierAdjustment().withTypeModifiers(SyntheticState.SYNTHETIC)).make()
+                .visit(new ModifierAdjustment().withTypeModifiers(SyntheticState.SYNTHETIC))
+                .make()
                 .getBytes();
-        ClassInfo classInfo = indexer.index(new ByteArrayInputStream(syntheticClass));
+        ClassInfo classInfo = IndexingUtil.indexSingle(syntheticClass);
         assertTrue(classInfo.isSynthetic());
     }
 
     @Test
     public void testMethodIsSynthetic() throws Exception {
-        Indexer indexer = new Indexer();
         final byte[] syntheticClass = new ByteBuddy().subclass(Object.class)
                 .visit(new ModifierAdjustment().withTypeModifiers(SyntheticState.SYNTHETIC))
-                .defineMethod("ping", String.class, SyntheticState.SYNTHETIC).intercept(FixedValue.value("Hello World!")).make()
+                .defineMethod("ping", String.class, SyntheticState.SYNTHETIC).intercept(FixedValue.value("Hello World!"))
+                .make()
                 .getBytes();
-        ClassInfo classInfo = indexer.index(new ByteArrayInputStream(syntheticClass));
+        ClassInfo classInfo = IndexingUtil.indexSingle(syntheticClass);
         assertTrue(classInfo.isSynthetic());
         MethodInfo ping = null;
         for (MethodInfo m : classInfo.methods()) {
@@ -60,11 +59,12 @@ public class ModifiersTestCase {
 
     @Test
     public void testFieldIsSynthetic() throws Exception {
-        Indexer indexer = new Indexer();
         final byte[] syntheticClass = new ByteBuddy().subclass(Object.class)
                 .visit(new ModifierAdjustment().withTypeModifiers(SyntheticState.SYNTHETIC))
-                .defineField("ping", String.class, SyntheticState.SYNTHETIC).make().getBytes();
-        ClassInfo classInfo = indexer.index(new ByteArrayInputStream(syntheticClass));
+                .defineField("ping", String.class, SyntheticState.SYNTHETIC)
+                .make()
+                .getBytes();
+        ClassInfo classInfo = IndexingUtil.indexSingle(syntheticClass);
         assertTrue(classInfo.isSynthetic());
         FieldInfo ping = null;
         for (FieldInfo f : classInfo.fields()) {

--- a/core/src/test/java/org/jboss/jandex/test/ModuleInfoTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/ModuleInfoTestCase.java
@@ -21,8 +21,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Arrays;
@@ -33,14 +31,13 @@ import java.util.Map;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.ModuleInfo;
 import org.jboss.jandex.ModuleInfo.ExportedPackageInfo;
 import org.jboss.jandex.ModuleInfo.OpenedPackageInfo;
 import org.jboss.jandex.ModuleInfo.ProvidedServiceInfo;
 import org.jboss.jandex.ModuleInfo.RequiredModuleInfo;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -137,14 +134,8 @@ public class ModuleInfoTestCase {
     private Index buildIndex() throws IOException {
         Indexer indexer = new Indexer();
         indexAvailableModuleInfo(indexer);
-
         Index index = indexer.complete();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(index);
-
-        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
-
-        return index;
+        return IndexingUtil.roundtrip(index);
     }
 
     /**

--- a/core/src/test/java/org/jboss/jandex/test/RecordTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/RecordTestCase.java
@@ -22,8 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -32,10 +30,9 @@ import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.RecordComponentInfo;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -165,12 +162,7 @@ public class RecordTestCase {
         indexer.index(getClass().getClassLoader().getResourceAsStream("test/RecordExample$AccessorAnnotation.class"));
 
         Index index = indexer.complete();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(index);
-
-        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
-
-        return index;
+        return IndexingUtil.roundtrip(index);
     }
 
 }

--- a/core/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
@@ -22,8 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -33,13 +31,12 @@ import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.ParameterizedType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 public class TypeAnnotationTestCase {
@@ -53,10 +50,7 @@ public class TypeAnnotationTestCase {
     @Test
     public void testReadWrite() throws IOException {
         Index index = buildIndex();
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(index);
-
-        index = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+        index = IndexingUtil.roundtrip(index);
 
         verifyTypeAnnotations(index);
     }

--- a/core/src/test/java/org/jboss/jandex/test/TypeUseTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeUseTestCase.java
@@ -20,8 +20,6 @@ package org.jboss.jandex.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
@@ -30,10 +28,9 @@ import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationTarget;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
 import org.jboss.jandex.TypeTarget;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 public class TypeUseTestCase {
@@ -95,9 +92,7 @@ public class TypeUseTestCase {
         // This has always worked fine
         verifyTypeUseAnnotations(originalIndex, annotationClass, expectedUsage, expectedEnclosingTargetKind);
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(originalIndex);
-        Index indexAfterWriteRead = new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
+        Index indexAfterWriteRead = IndexingUtil.roundtrip(originalIndex);
 
         // This used to fail with a ClassCastException because after the index was written, then read again,
         // the enclosing target in MethodParameterTypeTarget became a type,

--- a/core/src/test/java/org/jboss/jandex/test/Utf8ConstantEncodingTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/Utf8ConstantEncodingTest.java
@@ -3,7 +3,6 @@ package org.jboss.jandex.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,9 +10,8 @@ import java.lang.annotation.RetentionPolicy;
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
-import org.jboss.jandex.IndexReader;
-import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
+import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
 import net.bytebuddy.ByteBuddy;
@@ -67,7 +65,7 @@ public class Utf8ConstantEncodingTest {
 
         verifyAnnotationValue(index);
 
-        Index index2 = roundtrip(index);
+        Index index2 = IndexingUtil.roundtrip(index);
 
         verifyAnnotationValue(index2);
     }
@@ -76,11 +74,5 @@ public class Utf8ConstantEncodingTest {
         ClassInfo clazz = index.getClassByName(DotName.createSimple(CLASS_NAME));
         String annotationValue = clazz.classAnnotation(DotName.createSimple(MyAnnotation.class.getName())).value().asString();
         assertEquals(LONG_STRING, annotationValue);
-    }
-
-    private Index roundtrip(Index index) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        new IndexWriter(baos).write(index);
-        return new IndexReader(new ByteArrayInputStream(baos.toByteArray())).read();
     }
 }

--- a/core/src/test/java/org/jboss/jandex/test/util/IndexingUtil.java
+++ b/core/src/test/java/org/jboss/jandex/test/util/IndexingUtil.java
@@ -1,0 +1,36 @@
+package org.jboss.jandex.test.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.IndexReader;
+import org.jboss.jandex.IndexWriter;
+import org.jboss.jandex.Indexer;
+
+public class IndexingUtil {
+    public static ClassInfo indexSingle(Class<?> clazz) throws IOException {
+        return Index.of(clazz).getKnownClasses().iterator().next();
+    }
+
+    public static ClassInfo indexSingle(byte[] classData) throws IOException {
+        return indexSingle(new ByteArrayInputStream(classData));
+    }
+
+    public static ClassInfo indexSingle(InputStream classData) throws IOException {
+        Indexer indexer = new Indexer();
+        indexer.index(classData);
+        Index index = indexer.complete();
+        assert index.getKnownClasses().size() == 1;
+        return index.getKnownClasses().iterator().next();
+    }
+
+    public static Index roundtrip(Index index) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        new IndexWriter(bytes).write(index);
+        return new IndexReader(new ByteArrayInputStream(bytes.toByteArray())).read();
+    }
+}

--- a/maven-plugin/src/main/java/org/jboss/jandex/maven/JandexGoal.java
+++ b/maven-plugin/src/main/java/org/jboss/jandex/maven/JandexGoal.java
@@ -17,7 +17,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.IOUtil;
-import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.ClassSummary;
 import org.jboss.jandex.Index;
 import org.jboss.jandex.IndexWriter;
 import org.jboss.jandex.Indexer;
@@ -156,10 +156,10 @@ public class JandexGoal extends AbstractMojo {
                     try {
                         fis = new FileInputStream(new File(dir, file));
 
-                        final ClassInfo info = indexer.index(fis);
+                        final ClassSummary info = indexer.indexWithSummary(fis);
                         if (doVerbose() && info != null) {
-                            getLog().info("Indexed " + info.name() + " (" + info.annotations()
-                                    .size() + " annotations)");
+                            getLog().info("Indexed " + info.name() + " (" + info.annotationsCount()
+                                    + " annotations)");
                         }
                     } catch (final Exception e) {
                         throw new MojoExecutionException(e.getMessage(), e);


### PR DESCRIPTION
The `Indexer.index()` method used to return `ClassInfo`, which
assumes that no whole-index post-processing is not necessarsy.
Indeed Jandex doesn't do any such post-processing at the moment,
but it seems pretty obvious that it is necessary. Thus, as a first
step, this commit changes this method to return `void`, so that
all `Indexer` callers are forced to call `complete()` before
being able to access any kind of indexed information.

There are 2 kinds of usages of the `Indexer.index()` result of
the `ClassInfo` type in the Jandex project itself: showing some
summary during batch indexing and creating a single-class index
for tests.

For the first use case, a method `indexWithSummary` is added
that returns `ClassSummary`. This is fine and doesn't affect future
index post-processing, because the summary contains very high-level
information (just a name and number of annotations).

For the second use case, the `IndexingUtil` class is added which
contains utility methods for the most common cases of creating
a single-class index.

Additionally, the `IndexingUtil` class has a `rountrip` method
that serializes the index in memory and deserializes it back.
This is used in several tests, which usually had their own
variation of this code (one even serialized the index to a file).
This commit changes all such places to use this `roundtrip` method.

Fixes #132