### PR TITLE
Remove extra white space in between title and url of markdown link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Issues can be reported in the [Jandex JIRA Project](https://issues.jboss.org/bro
  
 ## Getting Help
 
-Post to the [WildFly user forums for help] (https://developer.jboss.org/en/wildfly?view=discussions).
+Post to the [WildFly user forums for help](https://developer.jboss.org/en/wildfly?view=discussions).
 
 ## Creating a Persisted Index Using the CLI
 


### PR DESCRIPTION
Just a minor typo