### PR TITLE
add IndexView.getKnownDirectSubinterfaces and getAllKnownSubinterfaces

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ClassInfo.java
+++ b/core/src/main/java/org/jboss/jandex/ClassInfo.java
@@ -34,7 +34,7 @@ import java.util.Map;
  * Only the methods and fields which are references by an annotation are stored.
  *
  * <p>
- * Global information including the parent class, implemented methodParameters, and
+ * Global information including the parent class, implemented interfaces, and
  * access flags are also provided since this information is often necessary.
  *
  * <p>
@@ -196,7 +196,7 @@ public final class ClassInfo implements AnnotationTarget {
      * @param name the name of this class
      * @param superName the name of the parent class
      * @param flags the class attributes
-     * @param interfaces the methodParameters this class implements
+     * @param interfaces the interfaces this class implements
      * @param annotations the annotations on this class
      * @param hasNoArgsConstructor whether this class has a no arg constructor
      * @return a new mock class representation

--- a/core/src/main/java/org/jboss/jandex/IndexView.java
+++ b/core/src/main/java/org/jboss/jandex/IndexView.java
@@ -67,7 +67,7 @@ public interface IndexView {
     }
 
     /**
-     * Gets all known direct subclasses of the specified class name. A known direct
+     * Gets all known direct subclasses of the specified class. A known direct
      * subclass is one which was found during the scanning process; however, this is
      * often not the complete universe of subclasses, since typically indexes are
      * constructed per jar. It is expected that several indexes will need to be searched
@@ -83,7 +83,7 @@ public interface IndexView {
     Collection<ClassInfo> getKnownDirectSubclasses(DotName className);
 
     /**
-     * Gets all known direct subclasses of the specified class name. A known direct
+     * Gets all known direct subclasses of the specified class. A known direct
      * subclass is one which was found during the scanning process; however, this is
      * often not the complete universe of subclasses, since typically indexes are
      * constructed per jar. It is expected that several indexes will need to be searched
@@ -101,7 +101,7 @@ public interface IndexView {
     }
 
     /**
-     * Gets all known direct subclasses of the specified class name. A known direct
+     * Gets all known direct subclasses of the specified class. A known direct
      * subclass is one which was found during the scanning process; however, this is
      * often not the complete universe of subclasses, since typically indexes are
      * constructed per jar. It is expected that several indexes will need to be searched
@@ -119,7 +119,7 @@ public interface IndexView {
     }
 
     /**
-     * Returns all known (including non-direct) sub classes of the given class.
+     * Returns all known (including non-direct) subclasses of the given class.
      * I.e., returns all known classes that are assignable to the given class.
      *
      * @param className The class
@@ -129,7 +129,7 @@ public interface IndexView {
     Collection<ClassInfo> getAllKnownSubclasses(final DotName className);
 
     /**
-     * Returns all known (including non-direct) sub classes of the given class.
+     * Returns all known (including non-direct) subclasses of the given class.
      * I.e., returns all known classes that are assignable to the given class.
      *
      * @param className The class
@@ -141,7 +141,7 @@ public interface IndexView {
     }
 
     /**
-     * Returns all known (including non-direct) sub classes of the given class.
+     * Returns all known (including non-direct) subclasses of the given class.
      * I.e., returns all known classes that are assignable to the given class.
      *
      * @param clazz The class
@@ -153,17 +153,107 @@ public interface IndexView {
     }
 
     /**
-     * Gets all known direct implementors of the specified interface name. A known
+     * Gets all known direct subinterfaces of the specified interface. A known direct
+     * subinterface is one which was found during the scanning process; however, this is
+     * often not the complete universe of subinterfaces, since typically indexes are
+     * constructed per jar. It is expected that several indexes will need to be searched
+     * when analyzing a jar that is a part of a complex multi-module/classloader
+     * environment (like an EE application server).
+     * <p>
+     * Note that this will only pick up direct subinterfaces of the interface. It will not
+     * pick up subinterfaces of subinterfaces.
+     *
+     * @param interfaceName the super interface of the desired subinterfaces
+     * @return a non-null list of all known subinterfaces of interfaceName
+     * @since 3.0
+     */
+    Collection<ClassInfo> getKnownDirectSubinterfaces(DotName interfaceName);
+
+    /**
+     * Gets all known direct subinterfaces of the specified interface. A known direct
+     * subinterface is one which was found during the scanning process; however, this is
+     * often not the complete universe of subinterfaces, since typically indexes are
+     * constructed per jar. It is expected that several indexes will need to be searched
+     * when analyzing a jar that is a part of a complex multi-module/classloader
+     * environment (like an EE application server).
+     * <p>
+     * Note that this will only pick up direct subinterfaces of the interface. It will not
+     * pick up subinterfaces of subinterfaces.
+     *
+     * @param interfaceName the super interface of the desired subinterfaces
+     * @return a non-null list of all known subinterfaces of interfaceName
+     * @since 3.0
+     */
+    default Collection<ClassInfo> getKnownDirectSubinterfaces(String interfaceName) {
+        return getKnownDirectSubinterfaces(DotName.createSimple(interfaceName));
+    }
+
+    /**
+     * Gets all known direct subinterfaces of the specified interface. A known direct
+     * subinterface is one which was found during the scanning process; however, this is
+     * often not the complete universe of subinterfaces, since typically indexes are
+     * constructed per jar. It is expected that several indexes will need to be searched
+     * when analyzing a jar that is a part of a complex multi-module/classloader
+     * environment (like an EE application server).
+     * <p>
+     * Note that this will only pick up direct subinterfaces of the interface. It will not
+     * pick up subinterfaces of subinterfaces.
+     *
+     * @param iface the super interface of the desired subinterfaces
+     * @return a non-null list of all known subinterfaces of iface
+     * @since 3.0
+     */
+    default Collection<ClassInfo> getKnownDirectSubinterfaces(Class<?> iface) {
+        return getKnownDirectSubinterfaces(DotName.createSimple(iface.getName()));
+    }
+
+    /**
+     * Returns all known interfaces that extend the given interface, directly and indirectly.
+     * I.e., returns every interface in the index that is assignable to the given interface.
+     *
+     * @param interfaceName The interace
+     * @return all known subinterfaces
+     * @since 3.0
+     */
+    Collection<ClassInfo> getAllKnownSubinterfaces(DotName interfaceName);
+
+    /**
+     * Returns all known interfaces that extend the given interface, directly and indirectly.
+     * I.e., returns every interface in the index that is assignable to the given interface.
+     *
+     * @param interfaceName The interace
+     * @return all known subinterfaces
+     * @since 3.0
+     */
+    default Collection<ClassInfo> getAllKnownSubinterfaces(String interfaceName) {
+        return getAllKnownSubinterfaces(DotName.createSimple(interfaceName));
+    }
+
+    /**
+     * Returns all known interfaces that extend the given interface, directly and indirectly.
+     * I.e., returns every interface in the index that is assignable to the given interface.
+     *
+     * @param iface The interace
+     * @return all known subinterfaces
+     * @since 3.0
+     */
+    default Collection<ClassInfo> getAllKnownSubinterfaces(Class<?> iface) {
+        return getAllKnownSubinterfaces(DotName.createSimple(iface.getName()));
+    }
+
+    /**
+     * Gets all known direct implementors of the specified interface. A known
      * direct implementor is one which was found during the scanning process; however,
      * this is often not the complete universe of implementors, since typically indexes
      * are constructed per jar. It is expected that several indexes will need to
      * be searched when analyzing a jar that is a part of a complex
      * multi-module/classloader environment (like an EE application server).
      * <p>
-     * The list of implementors may also include other methodParameters, in order to get a complete
-     * list of all classes that are assignable to a given interface it is necessary to
-     * recursively call {@link #getKnownDirectImplementors(DotName)} for every implementing
-     * interface found.
+     * The list of implementors also includes direct subinterfaces. This is inconsistent
+     * with {@link #getAllKnownImplementors(DotName)}, which doesn't return subinterfaces.
+     * <p>
+     * Note that this will only pick up classes that directly implement given interface.
+     * It will not pick up classes implementing subinterfaces.
      *
      * @param className the super class of the desired subclasses
      * @return a non-null list of all known subclasses of className
@@ -178,10 +268,11 @@ public interface IndexView {
      * be searched when analyzing a jar that is a part of a complex
      * multi-module/classloader environment (like an EE application server).
      * <p>
-     * The list of implementors may also include other methodParameters, in order to get a complete
-     * list of all classes that are assignable to a given interface it is necessary to
-     * recursively call {@link #getKnownDirectImplementors(DotName)} for every implementing
-     * interface found.
+     * The list of implementors also includes direct subinterfaces. This is inconsistent
+     * with {@link #getAllKnownImplementors(String)}, which doesn't return subinterfaces.
+     * <p>
+     * Note that this will only pick up classes that directly implement given interface.
+     * It will not pick up classes implementing subinterfaces.
      *
      * @param className the super class of the desired subclasses
      * @return a non-null list of all known subclasses of className
@@ -198,10 +289,11 @@ public interface IndexView {
      * be searched when analyzing a jar that is a part of a complex
      * multi-module/classloader environment (like an EE application server).
      * <p>
-     * The list of implementors may also include other methodParameters, in order to get a complete
-     * list of all classes that are assignable to a given interface it is necessary to
-     * recursively call {@link #getKnownDirectImplementors(DotName)} for every implementing
-     * interface found.
+     * The list of implementors also includes direct subinterfaces. This is inconsistent
+     * with {@link #getAllKnownImplementors(Class)}, which doesn't return subinterfaces.
+     * <p>
+     * Note that this will only pick up classes that directly implement given interface.
+     * It will not pick up classes implementing subinterfaces.
      *
      * @param clazz the super class of the desired subclasses
      * @return a non-null list of all known subclasses of className
@@ -212,11 +304,12 @@ public interface IndexView {
 
     /**
      * Returns all known classes that implement the given interface, directly and indirectly.
-     * This will all return classes that implement sub methodParameters of the interface, and
-     * sub-classes of classes that implement the interface. (In short, it will
-     * return every class that is assignable to the interface that is found in the index)
+     * This will return all classes that implement the interface and its subinterfaces,
+     * as well as subclasses of classes that implement the interface and its subinterfaces.
+     * (In short, it will return every class in the index that is assignable to the interface.)
      * <p>
-     * This will only return classes, not methodParameters.
+     * Note that this method only returns classes. Unlike {@link #getKnownDirectImplementors(DotName)},
+     * this method does not return subinterfaces of given interface.
      *
      * @param interfaceName The interface
      * @return All known implementors of the interface
@@ -225,11 +318,12 @@ public interface IndexView {
 
     /**
      * Returns all known classes that implement the given interface, directly and indirectly.
-     * This will all return classes that implement sub methodParameters of the interface, and
-     * sub-classes of classes that implement the interface. (In short, it will
-     * return every class that is assignable to the interface that is found in the index)
+     * This will return all classes that implement the interface and its subinterfaces,
+     * as well as subclasses of classes that implement the interface and its subinterfaces.
+     * (In short, it will return every class in the index that is assignable to the interface.)
      * <p>
-     * This will only return classes, not methodParameters.
+     * Note that this method only returns classes. Unlike {@link #getKnownDirectImplementors(String)},
+     * this method does not return subinterfaces of given interface.
      *
      * @param interfaceName The interface
      * @return All known implementors of the interface
@@ -240,11 +334,12 @@ public interface IndexView {
 
     /**
      * Returns all known classes that implement the given interface, directly and indirectly.
-     * This will all return classes that implement sub methodParameters of the interface, and
-     * sub-classes of classes that implement the interface. (In short, it will
-     * return every class that is assignable to the interface that is found in the index)
+     * This will return all classes that implement the interface and its subinterfaces,
+     * as well as subclasses of classes that implement the interface and its subinterfaces.
+     * (In short, it will return every class in the index that is assignable to the interface.)
      * <p>
-     * This will only return classes, not methodParameters.
+     * Note that this method only returns classes. Unlike {@link #getKnownDirectImplementors(Class)},
+     * this method does not return subinterfaces of given interface.
      *
      * @param interfaceClass The interface
      * @return All known implementors of the interface

--- a/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -188,6 +188,9 @@ final class IndexWriterV2 extends IndexWriterImpl {
         stream.writeByte(version);
         stream.writePackedU32(index.annotations.size());
         stream.writePackedU32(index.implementors.size());
+        if (version >= 11) {
+            stream.writePackedU32(index.subinterfaces.size());
+        }
         stream.writePackedU32(index.subclasses.size());
         if (version >= 10) {
             stream.writePackedU32(index.users.size());

--- a/core/src/test/java/org/jboss/jandex/test/CompositeTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/CompositeTestCase.java
@@ -37,8 +37,7 @@ import org.junit.jupiter.api.Test;
 public class CompositeTestCase {
 
     private static final DotName BASE_NAME = DotName.createSimple("foo.Base");
-    private static final DotName OBJECT_NAME = DotName.createSimple("java.lang.Object");
-    private static ClassInfo BASE_INFO = ClassInfo.create(BASE_NAME, OBJECT_NAME, (short) 0, new DotName[0],
+    private static final ClassInfo BASE_INFO = ClassInfo.create(BASE_NAME, DotName.OBJECT_NAME, (short) 0, new DotName[0],
             Collections.<DotName, List<AnnotationInstance>> emptyMap(), false);
     private static final DotName BAR_NAME = DotName.createSimple("foo.Bar");
     private static final DotName FOO_NAME = DotName.createSimple("foo.Foo");
@@ -60,9 +59,9 @@ public class CompositeTestCase {
         }
         assertEquals(3, hit);
 
-        assertEquals(5, verifyClasses(barIndex.getAllKnownSubclasses(OBJECT_NAME)));
-        assertEquals(6, verifyClasses(fooIndex.getAllKnownSubclasses(OBJECT_NAME)));
-        assertEquals(7, verifyClasses(index.getAllKnownSubclasses(OBJECT_NAME)));
+        assertEquals(5, verifyClasses(barIndex.getAllKnownSubclasses(DotName.OBJECT_NAME)));
+        assertEquals(6, verifyClasses(fooIndex.getAllKnownSubclasses(DotName.OBJECT_NAME)));
+        assertEquals(7, verifyClasses(index.getAllKnownSubclasses(DotName.OBJECT_NAME)));
     }
 
     private int verifyClasses(Collection<ClassInfo> allKnownSubclasses) {
@@ -82,9 +81,7 @@ public class CompositeTestCase {
 
     private Index createIndex(DotName name) {
         Map<DotName, List<AnnotationInstance>> annotations = new HashMap<DotName, List<AnnotationInstance>>();
-        DotName baseName = BASE_NAME;
-        ClassInfo classInfo = ClassInfo.create(name, baseName, (short) 0, new DotName[0], annotations, false);
-        ClassInfo baseInfo = BASE_INFO;
+        ClassInfo classInfo = ClassInfo.create(name, BASE_NAME, (short) 0, new DotName[0], annotations, false);
 
         AnnotationValue[] values = new AnnotationValue[] { AnnotationValue.createStringValue("blah", "blah") };
         DotName annotationName = DotName.createSimple("foo.BarAnno");
@@ -94,8 +91,8 @@ public class CompositeTestCase {
         Map<DotName, List<ClassInfo>> implementors = Collections.emptyMap();
         Map<DotName, ClassInfo> classes = Collections.singletonMap(name, classInfo);
         Map<DotName, List<ClassInfo>> subclasses = new HashMap<DotName, List<ClassInfo>>();
-        subclasses.put(OBJECT_NAME, Collections.singletonList(baseInfo));
-        subclasses.put(baseName, Collections.singletonList(classInfo));
+        subclasses.put(DotName.OBJECT_NAME, Collections.singletonList(BASE_INFO));
+        subclasses.put(BASE_NAME, Collections.singletonList(classInfo));
 
         return Index.create(annotations, subclasses, implementors, classes);
     }

--- a/core/src/test/java/org/jboss/jandex/test/SubtypesLookupTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SubtypesLookupTest.java
@@ -1,0 +1,118 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class SubtypesLookupTest {
+    interface Foo {
+    }
+
+    interface Bar extends Foo {
+    }
+
+    interface Baz extends Bar {
+    }
+
+    interface Quux {
+    }
+
+    static class A implements Foo {
+    }
+
+    static class B extends A implements Quux {
+    }
+
+    static class C extends B implements Bar {
+    }
+
+    static class D extends B implements Baz {
+    }
+
+    static class E implements Bar {
+    }
+
+    static class F implements Baz, Quux {
+    }
+
+    static class Z {
+    }
+
+    @Test
+    public void test() throws IOException {
+        Index index = Index.of(Foo.class, Bar.class, Baz.class, A.class, B.class, C.class, D.class, E.class, F.class, Z.class);
+        test(index);
+
+        test(IndexingUtil.roundtrip(index));
+    }
+
+    private void test(Index index) {
+        check(index.getKnownDirectSubclasses(Foo.class)); // empty
+        check(index.getKnownDirectSubinterfaces(Foo.class), "Bar");
+        check(index.getKnownDirectImplementors(Foo.class), "A", "Bar"); // Bar is intentional
+        check(index.getAllKnownSubclasses(Foo.class)); // empty
+        check(index.getAllKnownSubinterfaces(Foo.class), "Bar", "Baz");
+        check(index.getAllKnownImplementors(Foo.class), "A", "B", "C", "D", "E", "F");
+
+        check(index.getKnownDirectSubclasses(Bar.class)); // empty
+        check(index.getKnownDirectSubinterfaces(Bar.class), "Baz");
+        check(index.getKnownDirectImplementors(Bar.class), "C", "E", "Baz"); // Baz is intentional
+        check(index.getAllKnownSubclasses(Bar.class)); // empty
+        check(index.getAllKnownSubinterfaces(Bar.class), "Baz");
+        check(index.getAllKnownImplementors(Bar.class), "C", "D", "E", "F");
+
+        check(index.getKnownDirectSubclasses(Baz.class)); // empty
+        check(index.getKnownDirectSubinterfaces(Baz.class)); // empty
+        check(index.getKnownDirectImplementors(Baz.class), "D", "F");
+        check(index.getAllKnownSubclasses(Baz.class)); // empty
+        check(index.getAllKnownSubinterfaces(Baz.class)); // empty
+        check(index.getAllKnownImplementors(Baz.class), "D", "F");
+
+        check(index.getKnownDirectSubclasses(Quux.class)); // empty
+        check(index.getKnownDirectSubinterfaces(Quux.class)); // empty
+        check(index.getKnownDirectImplementors(Quux.class), "B", "F");
+        check(index.getAllKnownSubclasses(Quux.class)); // empty
+        check(index.getAllKnownSubinterfaces(Quux.class)); // empty
+        check(index.getAllKnownImplementors(Quux.class), "B", "C", "D", "F");
+
+        check(index.getKnownDirectSubclasses(A.class), "B");
+        check(index.getKnownDirectSubinterfaces(A.class)); // empty
+        check(index.getKnownDirectImplementors(A.class)); // empty
+        check(index.getAllKnownSubclasses(A.class), "B", "C", "D");
+        check(index.getAllKnownSubinterfaces(A.class)); // empty
+        check(index.getAllKnownImplementors(A.class)); // empty
+
+        check(index.getKnownDirectSubclasses(B.class), "C", "D");
+        check(index.getKnownDirectSubinterfaces(B.class)); // empty
+        check(index.getKnownDirectImplementors(B.class)); // empty
+        check(index.getAllKnownSubclasses(B.class), "C", "D");
+        check(index.getAllKnownSubinterfaces(B.class)); // empty
+        check(index.getAllKnownImplementors(B.class)); // empty
+
+        for (Class<?> clazz : Arrays.asList(C.class, D.class, E.class, F.class, Z.class)) {
+            check(index.getKnownDirectSubclasses(clazz)); // empty
+            check(index.getKnownDirectSubinterfaces(clazz)); // empty
+            check(index.getKnownDirectImplementors(clazz)); // empty
+            check(index.getAllKnownSubclasses(clazz)); // empty
+            check(index.getAllKnownSubinterfaces(clazz)); // empty
+            check(index.getAllKnownImplementors(clazz)); // empty
+        }
+    }
+
+    private void check(Collection<ClassInfo> lookedUpTypes, String... expectedTypes) {
+        Set<String> names = new HashSet<>();
+        for (ClassInfo lookedUpType : lookedUpTypes) {
+            names.add(lookedUpType.name().local());
+        }
+        assertEquals(new HashSet<>(Arrays.asList(expectedTypes)), names);
+    }
+}


### PR DESCRIPTION
This is technically a breaking change, but only for users who
extend/implement the `IndexView` interface. Callers are fine.
It is tempting to fix `IndexView.getKnownDirectImplementors`
to no longer return subinterfaces, but we refrain from doing so
to maintain behavioral compatibility.

This change requires persistent format version bump. That has already
happened on the `smallrye` branch, so this commit doesn't bump
again, but note that this commit can't be backported to Jandex 2.x.

Resolves #65