### PR TITLE
Introduce microbenchmarks, replace DotName.crossEquals() with DotName.componentizedEquals() 

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -1,0 +1,94 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.smallrye</groupId>
+        <artifactId>jandex-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>jandex-benchmarks</artifactId>
+
+    <name>Jandex: Microbenchmarks</name>
+
+    <properties>
+        <groupId.jandex>${project.groupId}</groupId.jandex>
+
+        <version.exec-maven-plugin>3.0.0</version.exec-maven-plugin>
+        <version.gson>2.8.6</version.gson>
+        <version.jandex>${project.version}</version.jandex>
+        <version.jmh>1.35</version.jmh>
+        <version.jmh-maven-plugin>0.2.2</version.jmh-maven-plugin>
+        <version.xchart>3.8.1</version.xchart>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${groupId.jandex}</groupId>
+            <artifactId>jandex</artifactId>
+            <version>${version.jandex}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${version.gson}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.knowm.xchart</groupId>
+            <artifactId>xchart</artifactId>
+            <version>${version.xchart}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>de.erichseifert.vectorgraphics2d</groupId>
+                    <artifactId>VectorGraphics2D</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>${version.jmh}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip> <!-- no actual tests in this module, just JMH-generated stuff -->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>${version.exec-maven-plugin}</version>
+            </plugin>
+            <plugin>
+                <groupId>pw.krejci</groupId>
+                <artifactId>jmh-maven-plugin</artifactId>
+                <version>${version.jmh-maven-plugin}</version>
+            </plugin>
+
+            <!-- this module shouldn't be released -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <configuration>
+                    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/benchmarks/run-benchmarks.sh
+++ b/benchmarks/run-benchmarks.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+VERSIONS="HEAD"
+BENCHMARKS=".*"
+
+help() {
+  echo "Usage: run-benchmarks.sh [--versions <versions>] [--benchmars <benchmarks>] [--help]"
+  echo
+  echo "  --versions <versions>: comma-separated list of Jandex versions (Git commits) to benchmark"
+  echo "                         defaults to 'HEAD'"
+  echo
+  echo "  --benchmarks <benchmarks>: comma-separated list of regexps that select the benchmarks to run"
+  echo "                             defaults to '.*'"
+  echo
+  echo "  --help: print this text"
+}
+
+while [[ $# -gt 0 ]] ; do
+  case $1 in
+    --help)
+      help
+      exit
+      ;;
+    --versions)
+      VERSIONS="${2//,/ }"
+      shift
+      shift
+      ;;
+    --benchmarks)
+      BENCHMARKS="$2"
+      shift
+      shift
+      ;;
+    *)
+      help
+      exit 1
+      ;;
+  esac
+done
+
+echo "Running benchmarks $BENCHMARKS against Jandex versions:"
+for VERSION in $VERSIONS ; do
+  echo "- $VERSION"
+done
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+for VERSION in $VERSIONS ; do
+  TEMP=$(mktemp --tmpdir -d jandex.XXXXXXXXXX)
+  git -C $ROOT_DIR archive $VERSION | tar -x -C $TEMP
+  pushd $TEMP
+  GROUP_ID=$(mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -q -DforceStdout -Dexpression=project.groupId)
+  mvn -q versions:set -DnewVersion=1.0.0-dev-SNAPSHOT
+  mvn -q versions:commit
+  mvn -q clean install -DskipTests -Dinvoker.skip -Dformat.skip -Dimpsort.skip
+  popd
+  rm -r $TEMP
+
+  mvn jmh:benchmark -Djmh.benchmarks=$BENCHMARKS -Djmh.rf=json -Djmh.rff=target/results-$VERSION.json -DgroupId.jandex=$GROUP_ID -Dversion.jandex=1.0.0-dev-SNAPSHOT
+done
+
+# this requires current Jandex workspace to be built and installed to local Maven repo (`mvn clean install -DskipTests`)
+RESULTS=$(find target -type f -name "results-*.json" -print0 | tr '\0' ',' | sed -e 's/,$//')
+mvn compile exec:java -Dexec.mainClass=org.jboss.jandex.chart.ChartGenerator -Dexec.arguments="$RESULTS"

--- a/benchmarks/src/main/java/org/jboss/jandex/Lump.java
+++ b/benchmarks/src/main/java/org/jboss/jandex/Lump.java
@@ -1,0 +1,5 @@
+package org.jboss.jandex;
+
+public class Lump {
+
+}

--- a/benchmarks/src/main/java/org/jboss/jandex/chart/AllBenchmarks.java
+++ b/benchmarks/src/main/java/org/jboss/jandex/chart/AllBenchmarks.java
@@ -1,0 +1,31 @@
+package org.jboss.jandex.chart;
+
+import org.jboss.jandex.json.BenchmarkDto;
+import org.openjdk.jmh.annotations.Mode;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AllBenchmarks {
+    public final Map<Mode, List<BenchmarksForVersion>> map = new HashMap<>();
+
+    public void add(String version, BenchmarkDto benchmark) {
+        Mode mode = Mode.deepValueOf(benchmark.mode);
+        List<BenchmarksForVersion> list = map.computeIfAbsent(mode, ignored -> new ArrayList<>());
+
+        // find existing `BenchmarksForVersion`
+        for (BenchmarksForVersion benchmarks : list) {
+            if (version.equals(benchmarks.version)) {
+                benchmarks.add(benchmark);
+                return;
+            }
+        }
+
+        // no existing `BenchmarksForVersion` found
+        BenchmarksForVersion benchmarks = new BenchmarksForVersion(version);
+        benchmarks.add(benchmark);
+        list.add(benchmarks);
+    }
+}

--- a/benchmarks/src/main/java/org/jboss/jandex/chart/BenchmarksForVersion.java
+++ b/benchmarks/src/main/java/org/jboss/jandex/chart/BenchmarksForVersion.java
@@ -1,0 +1,19 @@
+package org.jboss.jandex.chart;
+
+import org.jboss.jandex.json.BenchmarkDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BenchmarksForVersion {
+    public final String version;
+    public final List<BenchmarkDto> benchmarks = new ArrayList<>();
+
+    public BenchmarksForVersion(String version) {
+        this.version = version;
+    }
+
+    public void add(BenchmarkDto benchmark) {
+        benchmarks.add(benchmark);
+    }
+}

--- a/benchmarks/src/main/java/org/jboss/jandex/chart/ChartGenerator.java
+++ b/benchmarks/src/main/java/org/jboss/jandex/chart/ChartGenerator.java
@@ -1,0 +1,105 @@
+package org.jboss.jandex.chart;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.jboss.jandex.json.BenchmarkDto;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.BitmapEncoder.BitmapFormat;
+import org.knowm.xchart.CategoryChart;
+import org.knowm.xchart.CategoryChartBuilder;
+
+import com.google.gson.Gson;
+import org.openjdk.jmh.annotations.Mode;
+
+public class ChartGenerator {
+    private static final Gson GSON = new Gson();
+
+    public static void main(String[] args) throws IOException {
+        if (args.length == 0) {
+            return;
+        }
+
+        List<Path> files = new ArrayList<>();
+        for (String arg : args) {
+            Path file = Paths.get(arg);
+            if (!Files.isRegularFile(file) && !Files.isReadable(file)) {
+                throw new IllegalArgumentException("Can't read results file: " + file);
+            }
+            files.add(file);
+        }
+
+        AllBenchmarks allBenchmarks = new AllBenchmarks();
+        for (Path file : files) {
+            String version = file.getFileName().toString()
+                    .replace("results-", "")
+                    .replace(".json", "");
+            for (BenchmarkDto benchmark : readJson(file)) {
+                allBenchmarks.add(version, benchmark);
+            }
+        }
+
+        for (Map.Entry<Mode, List<BenchmarksForVersion>> entry : allBenchmarks.map.entrySet()) {
+            Mode mode = entry.getKey();
+            List<BenchmarksForVersion> allVersions = entry.getValue();
+
+            String unit = findCommonUnit(allVersions);
+
+            CategoryChart chart = new CategoryChartBuilder()
+                    .width(1280)
+                    .height(1024)
+                    .title("Jandex Microbenchmarks")
+                    .xAxisTitle("Benchmark")
+                    .yAxisTitle(mode.longLabel() + " (" + unit + ")")
+                    .build();
+            chart.getStyler()
+                    .setXAxisTicksVisible(true)
+                    .setXAxisLabelRotation(90);
+
+            for (BenchmarksForVersion benchmarksForVersion : allVersions) {
+                List<String> names = new ArrayList<>();
+                List<BigDecimal> scores = new ArrayList<>();
+                List<BigDecimal> errors = new ArrayList<>();
+
+                for (BenchmarkDto benchmark : benchmarksForVersion.benchmarks) {
+                    names.add(benchmark.shortName());
+                    scores.add(benchmark.primaryMetric.score);
+                    errors.add(benchmark.primaryMetric.scoreError);
+                }
+
+                chart.addSeries(benchmarksForVersion.version, names, scores, errors);
+            }
+
+            BitmapEncoder.saveBitmap(chart, "target/jandex-microbenchmarks-" + mode.shortLabel(), BitmapFormat.PNG);
+        }
+    }
+
+    private static BenchmarkDto[] readJson(Path inputFile) throws IOException {
+        try (Reader reader = Files.newBufferedReader(inputFile, StandardCharsets.UTF_8)) {
+            return GSON.fromJson(reader, BenchmarkDto[].class);
+        }
+    }
+
+    private static String findCommonUnit(List<BenchmarksForVersion> allVersions) {
+        Set<String> allUnits = allVersions.stream()
+                .flatMap(it -> it.benchmarks.stream())
+                .map(it -> it.primaryMetric.scoreUnit)
+                .collect(Collectors.toSet());
+        if (allUnits.size() != 1) {
+            // this should never happen
+            throw new IllegalStateException("Same mode benchmarks have different units: " + allUnits);
+        }
+        return allUnits.iterator().next();
+    }
+}

--- a/benchmarks/src/main/java/org/jboss/jandex/json/BenchmarkDto.java
+++ b/benchmarks/src/main/java/org/jboss/jandex/json/BenchmarkDto.java
@@ -1,0 +1,12 @@
+package org.jboss.jandex.json;
+
+public class BenchmarkDto {
+    public String benchmark;
+    public String mode;
+    public PrimaryMetricDto primaryMetric;
+
+    public String shortName() {
+        String[] parts = benchmark.split("\\.");
+        return parts[parts.length - 2] + "." + parts[parts.length - 1];
+    }
+}

--- a/benchmarks/src/main/java/org/jboss/jandex/json/PrimaryMetricDto.java
+++ b/benchmarks/src/main/java/org/jboss/jandex/json/PrimaryMetricDto.java
@@ -1,0 +1,9 @@
+package org.jboss.jandex.json;
+
+import java.math.BigDecimal;
+
+public class PrimaryMetricDto {
+    public BigDecimal score;
+    public BigDecimal scoreError;
+    public String scoreUnit;
+}

--- a/benchmarks/src/test/java/org/jboss/jandex/DotNameEqualsBenchmark.java
+++ b/benchmarks/src/test/java/org/jboss/jandex/DotNameEqualsBenchmark.java
@@ -1,0 +1,92 @@
+package org.jboss.jandex;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@Fork(5)
+@Warmup(iterations = 5, time = 1, batchSize = 8192)
+@Measurement(iterations = 5, time = 1, batchSize = 8192)
+@State(Scope.Benchmark)
+public class DotNameEqualsBenchmark {
+    private DotName simpleFoo1;
+    private DotName simpleFoo2;
+    private DotName simpleBar;
+    private DotName componentizedFoo1;
+    private DotName componentizedBar;
+    private DotName componentizedFoo2;
+
+    @Setup
+    public void setup() {
+        simpleFoo1 = DotName.createSimple("org.acme.Foo");
+        simpleFoo2 = DotName.createSimple("org.acme.Foo");
+        simpleBar = DotName.createSimple("org.acme.next.Bar");
+        DotName org = DotName.createComponentized(null, "org");
+        DotName acme = DotName.createComponentized(org, "acme");
+        componentizedFoo1 = DotName.createComponentized(acme, "Foo");
+        componentizedFoo2 = DotName.createComponentized(acme, "Foo");
+        DotName next = DotName.createComponentized(acme, "next");
+        componentizedBar = DotName.createComponentized(next, "Bar");
+    }
+
+    @Benchmark
+    public boolean simpleSimpleEquals() {
+        boolean test = simpleFoo1.equals(simpleFoo2);
+        if (!test) {
+            throw new IllegalStateException();
+        }
+        return test;
+    }
+
+    @Benchmark
+    public boolean simpleSimpleNotEquals() {
+        boolean test = simpleFoo1.equals(simpleBar);
+        if (test) {
+            throw new IllegalStateException();
+        }
+        return test;
+    }
+
+    @Benchmark
+    public boolean simpleComponentizedEquals() {
+        boolean test = simpleFoo1.equals(componentizedFoo1);
+        if (!test) {
+            throw new IllegalStateException();
+        }
+        return test;
+    }
+
+    @Benchmark
+    public boolean simpleComponentizedNotEquals() {
+        boolean test = simpleFoo1.equals(componentizedBar);
+        if (test) {
+            throw new IllegalStateException();
+        }
+        return test;
+    }
+
+    @Benchmark
+    public boolean componentizedComponentizedEquals() {
+        boolean test = componentizedFoo1.equals(componentizedFoo2);
+        if (!test) {
+            throw new IllegalStateException();
+        }
+        return test;
+    }
+
+    @Benchmark
+    public boolean componentizedComponentizedNotEquals() {
+        boolean test = componentizedFoo1.equals(componentizedBar);
+        if (test) {
+            throw new IllegalStateException();
+        }
+        return test;
+    }
+}

--- a/benchmarks/src/test/java/org/jboss/jandex/IndexAccessBenchmark.java
+++ b/benchmarks/src/test/java/org/jboss/jandex/IndexAccessBenchmark.java
@@ -1,0 +1,79 @@
+package org.jboss.jandex;
+
+import java.io.IOException;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.Throughput)
+@Fork(5)
+@Warmup(iterations = 5, time = 1, batchSize = 8192)
+@Measurement(iterations = 5, time = 1, batchSize = 8192)
+@State(Scope.Benchmark)
+public class IndexAccessBenchmark {
+    private IndexView index;
+    private DotName simpleLump;
+    private DotName simpleFool;
+    private DotName componentizedLump;
+    private DotName componentizedFool;
+
+    @Setup
+    public void setup() {
+        try {
+            index = Index.of(Lump.class);
+        } catch (IOException e) {
+            throw new IllegalStateException();
+        }
+        simpleLump = DotName.createSimple(Lump.class.getName());
+        simpleFool = DotName.createSimple("org.acme.Fool");
+        DotName org = DotName.createComponentized(null, "org");
+        DotName jboss = DotName.createComponentized(org, "jboss");
+        DotName jandex = DotName.createComponentized(jboss, "jandex");
+        componentizedLump = DotName.createComponentized(jandex, "Lump");
+        DotName acme = DotName.createComponentized(org, "acme");
+        componentizedFool = DotName.createComponentized(acme, "Fool");
+    }
+
+    @Benchmark
+    public ClassInfo getClassByNameSimple() {
+        ClassInfo clazz = index.getClassByName(simpleLump);
+        if (clazz == null) {
+            throw new IllegalStateException();
+        }
+        return clazz;
+    }
+
+    @Benchmark
+    public ClassInfo getClassByNameSimpleMiss() {
+        ClassInfo clazz = index.getClassByName(simpleFool);
+        if (clazz != null) {
+            throw new IllegalStateException();
+        }
+        return clazz;
+    }
+
+    @Benchmark
+    public ClassInfo getClassByNameComponentized() {
+        ClassInfo clazz = index.getClassByName(componentizedLump);
+        if (clazz == null) {
+            throw new IllegalStateException();
+        }
+        return clazz;
+    }
+
+    @Benchmark
+    public ClassInfo getClassByNameComponentizedMiss() {
+        ClassInfo clazz = index.getClassByName(componentizedFool);
+        if (clazz != null) {
+            throw new IllegalStateException();
+        }
+        return clazz;
+    }
+}

--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -343,50 +343,10 @@ public final class DotName implements Comparable<DotName> {
         if (other.prefix == null && prefix == null)
             return local.equals(other.local) && innerClass == other.innerClass;
 
-        if (!other.componentized && componentized)
-            return crossEquals(other, this);
-
-        if (other.componentized && !componentized)
-            return crossEquals(this, other);
+        if (this.hash != 0 && other.hash != 0 && this.hash != other.hash)
+            return false;
 
         return componentizedEquals(this, other);
-    }
-
-    private static boolean crossEquals(final DotName simple, final DotName comp) {
-        final String exactToMatch = simple.local;
-        // We start matching from the end, as that's what we have in componentized mode:
-        int cursor = 0;
-        final int len = exactToMatch.length();
-        for (DotName d = comp; d != null && cursor - 1 <= len; d = d.prefix) {
-            cursor += 1 + d.local.length();
-        }
-
-        if (--cursor != len) {
-            return false;
-        }
-
-        DotName current = comp;
-        while (current != null) {
-            final String nextFragment = current.local;
-            final int fragLength = nextFragment.length();
-            if (!exactToMatch.regionMatches(cursor - fragLength, nextFragment, 0, fragLength)) {
-                return false;
-            }
-            //Jump by fragment match, +1 for the separator symbol:
-            cursor = cursor - fragLength - 1;
-            if (cursor == -1) {
-                //Our exactToMatch reference is finished; just verify we consumed comp completely as well::
-                return current.prefix == null;
-            }
-            final char expectNext = current.innerClass ? '$' : '.';
-            if (exactToMatch.charAt(cursor) != expectNext) {
-                return false;
-            }
-
-            current = current.prefix;
-        }
-        //And finally, verify we consumed it all:
-        return cursor == -1;
     }
 
     private static boolean componentizedEquals(DotName a, DotName b) {

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,12 @@
     <name>Jandex: Parent</name>
 
     <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+
         <version.ant>1.10.11</version.ant>
         <version.apiviz>1.3.2.GA</version.apiviz>
         <version.bytebuddy>1.11.13</version.bytebuddy>
@@ -47,6 +53,8 @@
         <module>core</module>
         <module>maven-plugin</module>
         <module>test-data</module>
+
+        <module>benchmarks</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
According to the results there is no significant difference in performance of `DotName.crossEquals()` and `DotName.componentizedEquals()` and so it does not make sense to maintain two dedicated methods.