### PR TITLE
Fix wrong type parameter sharing in generic signature parser

### DIFF
--- a/core/src/main/java/org/jboss/jandex/GenericSignatureParser.java
+++ b/core/src/main/java/org/jboss/jandex/GenericSignatureParser.java
@@ -115,7 +115,7 @@ class GenericSignatureParser {
      *
      */
     // @formatter:on
-    private static WildcardType UNBOUNDED_WILDCARD = new WildcardType(null, true);
+    private static final WildcardType UNBOUNDED_WILDCARD = new WildcardType(null, true);
     private String signature;
     private int pos;
     private NameTable names;
@@ -245,6 +245,7 @@ class GenericSignatureParser {
         this.signature = signature;
         this.typeParameters = this.classTypeParameters;
         this.typeParameters.clear();
+        this.elementTypeParameters.clear();
         this.pos = 0;
         Type[] parameters = parseTypeParameters();
         Type superClass = names.intern(parseClassTypeSignature());

--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -2192,7 +2192,7 @@ public final class Indexer {
      * @return the master index for all scanned class streams
      */
     public Index complete() {
-        initIndexMaps();
+        initIndexMaps(); // if no class was indexed before calling `complete()`
 
         propagateTypeParameterBounds();
 

--- a/core/src/test/java/org/jboss/jandex/test/SignatureSharingTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SignatureSharingTest.java
@@ -1,0 +1,43 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Iterator;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+public class SignatureSharingTest {
+    public interface WithMethodSignature {
+        <E extends Runnable> E method(E arg);
+    }
+
+    public interface WithClassSignature<E extends Exception> extends Iterator<E> {
+    }
+
+    @Test
+    public void classSignatureOnly() throws Exception {
+        test(Index.of(WithClassSignature.class));
+    }
+
+    @Test
+    public void classSignatureBeforeMethodSignature() throws Exception {
+        test(Index.of(WithClassSignature.class, WithMethodSignature.class));
+    }
+
+    @Test
+    public void classSignatureAfterMethodSignature() throws Exception {
+        test(Index.of(WithMethodSignature.class, WithClassSignature.class));
+    }
+
+    private void test(Index index) {
+        ClassInfo clazz = index.getClassByName(WithClassSignature.class);
+        DotName bound = clazz.interfaceTypes().get(0).asParameterizedType() // Iterator<E>
+                .arguments().get(0).asTypeVariable() // E
+                .bounds().get(0).asClassType().name(); // E's bound
+
+        assertEquals(DotName.createSimple(Exception.class.getName()), bound);
+    }
+}


### PR DESCRIPTION
The generic signature parser used to forget previously encountered
element-level type parameters when parsing a signature of a new
element, and previously encountered class-level type parameters when
parsing a signature of a new class. This leaves a hole: previously
encountered element-level type parameters could be used when
parsing a signature of a new class. When parsing a signature of
a new class, previously encountered element-level type parameters
must also be forgotten, to prevent wrong sharing.

Fixes #98