### PR TITLE
add methods to Index to work with packages

### DIFF
--- a/core/src/main/java/org/jboss/jandex/CompositeIndex.java
+++ b/core/src/main/java/org/jboss/jandex/CompositeIndex.java
@@ -320,4 +320,33 @@ public class CompositeIndex implements IndexView {
         }
         return Collections.unmodifiableCollection(users);
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Collection<ClassInfo> getClassesInPackage(DotName packageName) {
+        List<ClassInfo> result = new ArrayList<>();
+        Set<DotName> alreadySeen = new HashSet<>();
+        for (IndexView index : indexes) {
+            for (ClassInfo clazz : index.getClassesInPackage(packageName)) {
+                if (alreadySeen.add(clazz.name())) {
+                    result.add(clazz);
+                }
+            }
+        }
+        return Collections.unmodifiableCollection(result);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<DotName> getSubpackages(DotName packageName) {
+        Set<DotName> result = new HashSet<>();
+        for (IndexView index : indexes) {
+            result.addAll(index.getSubpackages(packageName));
+        }
+        return Collections.unmodifiableSet(result);
+    }
 }

--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -188,7 +188,7 @@ public final class DotName implements Comparable<DotName> {
     }
 
     /**
-     * Returns the package portion of this DotName.
+     * Returns the package portion of this {@link DotName}.
      *
      * @return the package name or null if this {@link DotName} has no package prefix
      * @since 2.4
@@ -202,6 +202,25 @@ public final class DotName implements Comparable<DotName> {
         } else {
             int index = local.lastIndexOf('.');
             return index == -1 ? null : local.substring(0, index);
+        }
+    }
+
+    /**
+     * Returns the package portion of this {@link DotName}. This is a {@code DotName}-returning
+     * variant of {@link #packagePrefix()}.
+     *
+     * @return the package name or {@code null} if this {@link DotName} has no package prefix
+     * @since 3.0
+     */
+    public DotName packagePrefixName() {
+        if (componentized) {
+            if (innerClass) {
+                return prefix.packagePrefixName();
+            }
+            return prefix;
+        } else {
+            int index = local.lastIndexOf('.');
+            return index == -1 ? null : DotName.createSimple(local.substring(0, index));
         }
     }
 

--- a/core/src/main/java/org/jboss/jandex/IndexView.java
+++ b/core/src/main/java/org/jboss/jandex/IndexView.java
@@ -19,6 +19,7 @@
 package org.jboss.jandex;
 
 import java.util.Collection;
+import java.util.Set;
 
 /**
  * The basic contract for accessing Jandex indexed information.
@@ -479,5 +480,77 @@ public interface IndexView {
      */
     default Collection<ClassInfo> getKnownUsers(Class<?> clazz) {
         return getKnownUsers(DotName.createSimple(clazz.getName()));
+    }
+
+    /**
+     * Returns all {@linkplain ClassInfo classes} known to this index that are present in given package.
+     * Classes present in subpackages of given package are not returned. Classes present in the unnamed
+     * package may be looked up using {@code null} as the package name. If this index does not contain
+     * any class in given package, returns an empty collection.
+     * <p>
+     * In the default {@link Index} implementation, this information is not stored in the index initially.
+     * Instead, an index of classes by package name is constructed on demand (on the first invocation
+     * of this method).
+     *
+     * @param packageName package name in the common, dot-separated form (e.g. {@code com.example.foobar});
+     *        {@code null} means the unnamed package
+     * @return immutable collection of classes present in given package, never {@code null}
+     */
+    Collection<ClassInfo> getClassesInPackage(DotName packageName);
+
+    /**
+     * Returns all {@linkplain ClassInfo classes} known to this index that are present in given package.
+     * Classes present in subpackages of given package are not returned. Classes present in the unnamed
+     * package may be looked up using {@code null} as the package name. If this index does not contain
+     * any class in given package, returns an empty collection.
+     * <p>
+     * In the default {@link Index} implementation, this information is not stored in the index initially.
+     * Instead, an index of classes by package name is constructed on demand (on the first invocation
+     * of this method).
+     *
+     * @param packageName package name in the common, dot-separated form (e.g. {@code com.example.foobar});
+     *        {@code null} means the unnamed package
+     * @return immutable collection of classes present in given package, never {@code null}
+     */
+    default Collection<ClassInfo> getClassesInPackage(String packageName) {
+        return getClassesInPackage(DotName.createSimple(packageName));
+    }
+
+    /**
+     * Returns a set of packages known to this index that are direct subpackages of given package.
+     * Indirect subpackages of given package (subpackages of subpackages) are not returned.
+     * If this index does not contain any class in a direct or indirect subpackage of given package,
+     * returns an empty collection.
+     * <p>
+     * Given that the unnamed package may not contain subpackages, passing {@code null} as the package
+     * name is permitted, but always results in an empty set.
+     * <p>
+     * In the default {@link Index} implementation, this information is not stored in the index initially.
+     * Instead, an index of packages is constructed on demand (on the first invocation of this method).
+     *
+     * @param packageName package name in the common, dot-separated form (e.g. {@code com.example.foobar});
+     *        {@code null} means the unnamed package
+     * @return immutable set of subpackages of given package, never {@code null}
+     */
+    Set<DotName> getSubpackages(DotName packageName);
+
+    /**
+     * Returns a set of packages known to this index that are direct subpackages of given package.
+     * Indirect subpackages of given package (subpackages of subpackages) are not returned.
+     * If this index does not contain any class in a direct or indirect subpackage of given package,
+     * returns an empty collection.
+     * <p>
+     * Given that the unnamed package may not contain subpackages, passing {@code null} as the package
+     * name is permitted, but always results in an empty set.
+     * <p>
+     * In the default {@link Index} implementation, this information is not stored in the index initially.
+     * Instead, an index of packages is constructed on demand (on the first invocation of this method).
+     *
+     * @param packageName package name in the common, dot-separated form (e.g. {@code com.example.foobar});
+     *        {@code null} means the unnamed package
+     * @return immutable set of subpackages of given package, never {@code null}
+     */
+    default Set<DotName> getSubpackages(String packageName) {
+        return getSubpackages(DotName.createSimple(packageName));
     }
 }

--- a/core/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/DotNameTestCase.java
@@ -184,7 +184,7 @@ public class DotNameTestCase {
     }
 
     @Test
-    public void testpackgePrefix() {
+    public void testPackagePrefix() {
         DotName foo = DotName.createComponentized(DotName.createComponentized(null, "root"), "thefoo");
         foo = DotName.createComponentized(foo, "Foo");
         assertEquals("root.thefoo", foo.packagePrefix());
@@ -194,6 +194,19 @@ public class DotNameTestCase {
         assertEquals("root.thefoo", inner2.packagePrefix());
         assertEquals("foo.bar.baz", DotName.createSimple("foo.bar.baz.Foo").packagePrefix());
         assertNull(DotName.createSimple("Foo").packagePrefix());
+    }
+
+    @Test
+    public void testPackagePrefixName() {
+        DotName foo = DotName.createComponentized(DotName.createComponentized(null, "root"), "thefoo");
+        foo = DotName.createComponentized(foo, "Foo");
+        assertEquals(DotName.createSimple("root.thefoo"), foo.packagePrefixName());
+        DotName inner = DotName.createComponentized(foo, "Inner", true);
+        DotName inner2 = DotName.createComponentized(inner, "Inner2", true);
+        assertEquals(DotName.createSimple("root.thefoo"), inner.packagePrefixName());
+        assertEquals(DotName.createSimple("root.thefoo"), inner2.packagePrefixName());
+        assertEquals(DotName.createSimple("foo.bar.baz"), DotName.createSimple("foo.bar.baz.Foo").packagePrefixName());
+        assertNull(DotName.createSimple("Foo").packagePrefixName());
     }
 
     @Test

--- a/core/src/test/java/org/jboss/jandex/test/PackagesTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/PackagesTest.java
@@ -1,0 +1,82 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.Index;
+import org.junit.jupiter.api.Test;
+
+public class PackagesTest {
+    @Test
+    public void getClassesInPackage() throws IOException {
+        Index index = Index.of(PackagesTest.class, String.class, List.class, AtomicInteger.class);
+
+        Collection<ClassInfo> classes = index.getClassesInPackage("java.lang");
+        assertEquals(1, classes.size());
+        assertEquals("java.lang.String", classes.iterator().next().name().toString());
+
+        classes = index.getClassesInPackage("java.util");
+        assertEquals(1, classes.size());
+        assertEquals("java.util.List", classes.iterator().next().name().toString());
+
+        classes = index.getClassesInPackage("java.util.concurrent");
+        assertTrue(classes.isEmpty());
+
+        classes = index.getClassesInPackage("java.util.concurrent.atomic");
+        assertEquals(1, classes.size());
+        assertEquals("java.util.concurrent.atomic.AtomicInteger", classes.iterator().next().name().toString());
+
+        classes = index.getClassesInPackage("org.jboss.jandex.test");
+        assertEquals(1, classes.size());
+        assertEquals("org.jboss.jandex.test.PackagesTest", classes.iterator().next().name().toString());
+
+        classes = index.getClassesInPackage((DotName) null);
+        assertTrue(classes.isEmpty());
+    }
+
+    @Test
+    public void getSubpackages() throws IOException {
+        Index index = Index.of(PackagesTest.class, String.class, List.class, AtomicInteger.class);
+
+        Collection<DotName> packages = index.getSubpackages("java");
+        assertEquals(2, packages.size());
+        assertTrue(packages.contains(DotName.createSimple("java.lang")));
+        assertTrue(packages.contains(DotName.createSimple("java.util")));
+
+        packages = index.getSubpackages("java.util");
+        assertEquals(1, packages.size());
+        assertTrue(packages.contains(DotName.createSimple("java.util.concurrent")));
+
+        packages = index.getSubpackages("java.util.concurrent");
+        assertEquals(1, packages.size());
+        assertTrue(packages.contains(DotName.createSimple("java.util.concurrent.atomic")));
+
+        packages = index.getSubpackages("java.util.concurrent.atomic");
+        assertEquals(0, packages.size());
+
+        packages = index.getSubpackages("org");
+        assertEquals(1, packages.size());
+        assertTrue(packages.contains(DotName.createSimple("org.jboss")));
+
+        packages = index.getSubpackages("org.jboss");
+        assertEquals(1, packages.size());
+        assertTrue(packages.contains(DotName.createSimple("org.jboss.jandex")));
+
+        packages = index.getSubpackages("org.jboss.jandex");
+        assertEquals(1, packages.size());
+        assertTrue(packages.contains(DotName.createSimple("org.jboss.jandex.test")));
+
+        packages = index.getSubpackages("org.jboss.jandex.test");
+        assertEquals(0, packages.size());
+
+        packages = index.getSubpackages((DotName) null);
+        assertTrue(packages.isEmpty());
+    }
+}


### PR DESCRIPTION
Two new methods, `getClassesInPackage` and `getSubpackages`, are added
to `IndexView`. Unlike other index methods, these don't expect to have
precomputed answers stored in the persistent format. The packages info
can be recomputed rather easily from the full set of known classes, so
these methods just initialize their "index" on demand. First call then
may be slow, but subsequent calls will be fast.

Resolves #96