### PR TITLE
improve type annotations handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
           enableMavenLocal=true
           jandex.version=1.0.0-dev-SNAPSHOT
           skipJandex=false
+        maven-local-ignore-paths: |
+          org/jboss/jandex/
+          io/smallrye/jandex/
 
     - name: Prepare failure archive (if run failed)
       if: failure()

--- a/core/src/main/java/org/jboss/jandex/DotName.java
+++ b/core/src/main/java/org/jboss/jandex/DotName.java
@@ -195,6 +195,9 @@ public final class DotName implements Comparable<DotName> {
      */
     public String packagePrefix() {
         if (componentized) {
+            if (prefix == null) {
+                return null;
+            }
             if (innerClass) {
                 return prefix.packagePrefix();
             }
@@ -214,6 +217,9 @@ public final class DotName implements Comparable<DotName> {
      */
     public DotName packagePrefixName() {
         if (componentized) {
+            if (prefix == null) {
+                return null;
+            }
             if (innerClass) {
                 return prefix.packagePrefixName();
             }

--- a/core/src/main/java/org/jboss/jandex/ParameterizedType.java
+++ b/core/src/main/java/org/jboss/jandex/ParameterizedType.java
@@ -140,8 +140,12 @@ public class ParameterizedType extends Type {
             appendAnnotations(builder);
             builder.append(name().local());
         } else {
+            String packagePrefix = name().packagePrefix();
+            if (packagePrefix != null) {
+                builder.append(packagePrefix).append('.');
+            }
             appendAnnotations(builder);
-            builder.append(name());
+            builder.append(name().withoutPackagePrefix());
         }
 
         if (arguments.length > 0) {

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -319,8 +319,12 @@ public abstract class Type {
 
     String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
+        String packagePrefix = name.packagePrefix();
+        if (packagePrefix != null) {
+            builder.append(packagePrefix).append('.');
+        }
         appendAnnotations(builder);
-        builder.append(name);
+        builder.append(name.withoutPackagePrefix());
 
         return builder.toString();
     }

--- a/core/src/test/java/org/jboss/jandex/test/BridgeMethodTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/BridgeMethodTestCase.java
@@ -47,7 +47,7 @@ public class BridgeMethodTestCase {
                 "test/BridgeMethods$NestedConsumer.class",
                 "accept",
                 TypeTarget.Usage.METHOD_PARAMETER, "java.lang.Object",
-                "@Nullable test.BridgeMethods$NestedConsumer");
+                "test.@Nullable BridgeMethods$NestedConsumer");
     }
 
     @Test
@@ -56,7 +56,7 @@ public class BridgeMethodTestCase {
                 "test/BridgeMethods$ArrayWithNullableElementsConsumer.class",
                 "accept",
                 TypeTarget.Usage.METHOD_PARAMETER, "java.lang.Object",
-                "@Nullable java.lang.Object[]");
+                "java.lang.@Nullable Object[]");
     }
 
     @Test
@@ -64,7 +64,7 @@ public class BridgeMethodTestCase {
         verifyMethodSignature(
                 "test/BridgeMethods$NullableArrayConsumer.class",
                 "accept",
-                TypeTarget.Usage.METHOD_PARAMETER, "@Nullable java.lang.Object",
+                TypeTarget.Usage.METHOD_PARAMETER, "java.lang.@Nullable Object",
                 "java.lang.Object @Nullable []");
     }
 
@@ -73,8 +73,8 @@ public class BridgeMethodTestCase {
         verifyMethodSignature(
                 "test/BridgeMethods$NullableArrayWithNullableElementsConsumer.class",
                 "accept",
-                TypeTarget.Usage.METHOD_PARAMETER, "@Nullable java.lang.Object",
-                "@Nullable java.lang.Object @Nullable []");
+                TypeTarget.Usage.METHOD_PARAMETER, "java.lang.@Nullable Object",
+                "java.lang.@Nullable Object @Nullable []");
     }
 
     @Test
@@ -84,7 +84,7 @@ public class BridgeMethodTestCase {
                 "get",
                 TypeTarget.Usage.EMPTY,
                 "java.lang.Object",
-                "@Nullable java.lang.Object[]");
+                "java.lang.@Nullable Object[]");
     }
 
     @Test
@@ -93,7 +93,7 @@ public class BridgeMethodTestCase {
                 "test/BridgeMethods$NullableArraySupplier.class",
                 "get",
                 TypeTarget.Usage.EMPTY,
-                "@Nullable java.lang.Object",
+                "java.lang.@Nullable Object",
                 "java.lang.Object @Nullable []");
     }
 

--- a/core/src/test/java/org/jboss/jandex/test/TypeAnnotationOnLocalClassTypeTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeAnnotationOnLocalClassTypeTest.java
@@ -1,0 +1,245 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class TypeAnnotationOnLocalClassTypeTest {
+    @Target(ElementType.TYPE_USE)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface TypeAnn {
+        String value();
+
+        DotName DOT_NAME = DotName.createSimple(TypeAnn.class.getName());
+    }
+
+    class C1 {
+        class C2 {
+            class C3 {
+                class C4 {
+                    class C5 {
+                    }
+                }
+            }
+        }
+    }
+
+    static class SC1 {
+        static class SC2 {
+            static class SC3 {
+                static class SC4 {
+                    static class SC5 {
+                        class C6 {
+                            class C7 {
+                                class C8 {
+                                    class C9 {
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    static class NestedClass {
+        class NestedInnerClass {
+        }
+    }
+
+    class InnerClass {
+        class InnerInnerClass {
+        }
+
+        Object method() {
+            class LocalClass extends RuntimeException {
+            }
+
+            class AnotherLocalClass extends @TypeAnn("local:extends") LocalClass {
+                @TypeAnn("test")
+                TypeAnnotationOnLocalClassTypeTest.@TypeAnn("c1") C1.C2.C3.@TypeAnn("c4") C4.C5 a;
+
+                TypeAnnotationOnLocalClassTypeTest.SC1.SC2.SC3.SC4.@TypeAnn("sc5") SC5 b;
+
+                TypeAnnotationOnLocalClassTypeTest.SC1.SC2.SC3.SC4.@TypeAnn("sc5") SC5.C6.@TypeAnn("c7") C7.@TypeAnn("c8") C8.C9 c;
+
+                TypeAnnotationOnLocalClassTypeTest.@TypeAnn("nested") NestedClass.@TypeAnn("nested inner") NestedInnerClass nested;
+
+                @TypeAnn("test")
+                TypeAnnotationOnLocalClassTypeTest.@TypeAnn("inner") InnerClass.@TypeAnn("inner inner") InnerInnerClass inner;
+
+                @TypeAnn("local:field")
+                LocalClass local;
+
+                LocalClass[] @TypeAnn("local:array") [] localArray;
+
+                @TypeAnn("local:array element")
+                LocalClass @TypeAnn("local:array dimension") [] localArrayBoth;
+
+                @TypeAnn("local:method return")
+                LocalClass methodA() {
+                    return null;
+                }
+
+                void methodB(@TypeAnn("local:param") LocalClass param) {
+                }
+
+                <@TypeAnn("local:type param") X extends @TypeAnn("local:type param bound") LocalClass> void methodC() {
+                }
+
+                void methodD(List<@TypeAnn("local:type arg") LocalClass> param) {
+                }
+
+                void methodE() throws @TypeAnn("local:throws") LocalClass {
+                }
+            }
+
+            return new AnotherLocalClass();
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+        Class<?> clazz = new TypeAnnotationOnLocalClassTypeTest().new InnerClass().method().getClass();
+        Index index = Index.of(clazz);
+
+        test(index, clazz);
+
+        test(IndexingUtil.roundtrip(index), clazz);
+    }
+
+    private void test(Index index, Class<?> clazz) {
+        ClassInfo classInfo = index.getClassByName(clazz);
+        assertNotNull(classInfo);
+        assertEquals(clazz.getName(), classInfo.name().toString());
+
+        {
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"local:extends\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass",
+                    classInfo.superClassType().toString());
+            assertEquals(1, classInfo.annotations()
+                    .stream()
+                    .filter(it -> it.name().equals(TypeAnn.DOT_NAME) && it.value().asString().equals("local:extends"))
+                    .count());
+        }
+
+        {
+            FieldInfo a = classInfo.field("a");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"test\") TypeAnnotationOnLocalClassTypeTest.@TypeAnn(\"c1\") C1.C2.C3.@TypeAnn(\"c4\") C4.C5",
+                    a.type().toString());
+            assertEquals(3, a.annotations().size());
+        }
+
+        {
+            FieldInfo b = classInfo.field("b");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"sc5\") TypeAnnotationOnLocalClassTypeTest$SC1$SC2$SC3$SC4$SC5",
+                    b.type().toString());
+            assertEquals(1, b.annotations().size());
+        }
+
+        {
+            FieldInfo c = classInfo.field("c");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"sc5\") TypeAnnotationOnLocalClassTypeTest$SC1$SC2$SC3$SC4$SC5.C6.@TypeAnn(\"c7\") C7.@TypeAnn(\"c8\") C8.C9",
+                    c.type().toString());
+            assertEquals(3, c.annotations().size());
+        }
+
+        {
+            FieldInfo nested = classInfo.field("nested");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"nested\") TypeAnnotationOnLocalClassTypeTest$NestedClass.@TypeAnn(\"nested inner\") NestedInnerClass",
+                    nested.type().toString());
+            assertEquals(2, nested.annotations().size());
+        }
+
+        {
+            FieldInfo inner = classInfo.field("inner");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"test\") TypeAnnotationOnLocalClassTypeTest.@TypeAnn(\"inner\") InnerClass.@TypeAnn(\"inner inner\") InnerInnerClass",
+                    inner.type().toString());
+            assertEquals(3, inner.annotations().size());
+        }
+
+        {
+            FieldInfo local = classInfo.field("local");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"local:field\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass",
+                    local.type().toString());
+            assertEquals(1, local.annotations().size());
+        }
+
+        {
+            FieldInfo localArray = classInfo.field("localArray");
+            assertEquals(
+                    "org.jboss.jandex.test.TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass[] @TypeAnn(\"local:array\") []",
+                    localArray.type().toString());
+            assertEquals(1, localArray.annotations().size());
+        }
+
+        {
+            FieldInfo localArrayBoth = classInfo.field("localArrayBoth");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"local:array element\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass @TypeAnn(\"local:array dimension\") []",
+                    localArrayBoth.type().toString());
+            assertEquals(2, localArrayBoth.annotations().size());
+        }
+
+        {
+            MethodInfo methodA = classInfo.firstMethod("methodA");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"local:method return\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass",
+                    methodA.returnType().toString());
+            assertEquals(1, methodA.annotations().size());
+        }
+
+        {
+            MethodInfo methodB = classInfo.firstMethod("methodB");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"local:param\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass",
+                    methodB.parameterType(0).toString());
+            assertEquals(1, methodB.annotations().size());
+        }
+
+        {
+            MethodInfo methodC = classInfo.firstMethod("methodC");
+            assertEquals(
+                    "@TypeAnn(\"local:type param\") X extends org.jboss.jandex.test.@TypeAnn(\"local:type param bound\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass",
+                    methodC.typeParameters().get(0).toString());
+            assertEquals(2, methodC.annotations().size());
+        }
+
+        {
+            MethodInfo methodD = classInfo.firstMethod("methodD");
+            assertEquals(
+                    "java.util.List<org.jboss.jandex.test.@TypeAnn(\"local:type arg\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass>",
+                    methodD.parameterType(0).toString());
+            assertEquals(1, methodD.annotations().size());
+        }
+
+        {
+            MethodInfo methodE = classInfo.firstMethod("methodE");
+            assertEquals(
+                    "org.jboss.jandex.test.@TypeAnn(\"local:throws\") TypeAnnotationOnLocalClassTypeTest$InnerClass$1LocalClass",
+                    methodE.exceptions().get(0).toString());
+            assertEquals(1, methodE.annotations().size());
+        }
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
@@ -326,7 +326,6 @@ public class TypeAnnotationTestCase {
         verifyHasAnnotation(nestName(clazz, "J"), type);
         assertEquals(Type.Kind.PARAMETERIZED_TYPE, type.kind());
         verifyName(nestName(clazz, "O1", "O2", "O3", "Nested"), type);
-
         type = type.asParameterizedType().owner();
         verifyHasAnnotation(nestName(clazz, "K"), type);
         assertEquals(Type.Kind.PARAMETERIZED_TYPE, type.kind());

--- a/core/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
@@ -42,7 +42,7 @@ public class TypeParameterBoundTestCase {
     public void listConsumer() throws IOException {
         ClassInfo info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$ListConsumer.class"));
         assertEquals(
-                "T extends @Nullable java.util.List",
+                "T extends java.util.@Nullable List",
                 info.typeParameters().get(0).toString());
     }
 
@@ -50,7 +50,7 @@ public class TypeParameterBoundTestCase {
     public void arrayListConsumer() throws IOException {
         ClassInfo info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$ArrayListConsumer.class"));
         assertEquals(
-                "T extends @Nullable java.util.ArrayList",
+                "T extends java.util.@Nullable ArrayList",
                 info.typeParameters().get(0).toString());
     }
 
@@ -59,21 +59,21 @@ public class TypeParameterBoundTestCase {
         ClassInfo info = IndexingUtil
                 .indexSingle(getClassBytes("test/TypeParameterBoundExample$SerializableListConsumer.class"));
         assertEquals(
-                "T extends @Nullable java.util.List & @Untainted java.io.Serializable",
+                "T extends java.util.@Nullable List & java.io.@Untainted Serializable",
                 info.typeParameters().get(0).toString());
     }
 
     @Test
     public void classExtendsOnInner() throws IOException {
         ClassInfo info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$IteratorSupplier.class"));
-        assertEquals("java.util.function.Supplier<java.util.function.Consumer<@Nullable java.lang.Object[]>>",
+        assertEquals("java.util.function.Supplier<java.util.function.Consumer<java.lang.@Nullable Object[]>>",
                 info.interfaceTypes().get(0).toString());
     }
 
     @Test
     public void classExtendsOnAnonInInner() throws IOException {
         ClassInfo info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$IteratorSupplier$1.class"));
-        assertEquals("java.util.function.Consumer<@Nullable java.lang.Object[]>",
+        assertEquals("java.util.function.Consumer<java.lang.@Nullable Object[]>",
                 info.interfaceTypes().get(0).toString());
     }
 
@@ -81,11 +81,11 @@ public class TypeParameterBoundTestCase {
     public void classExtendsNestAnonExtendsInner() throws IOException {
         ClassInfo info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$Nest1$Nest2$Nest3$1$1.class"));
         assertEquals(
-                "test.TypeParameterBoundExample$Nest1<java.lang.String>.Nest2<java.lang.Object[]>.Nest3<@Nullable java.lang.Integer>",
+                "test.TypeParameterBoundExample$Nest1<java.lang.String>.Nest2<java.lang.Object[]>.Nest3<java.lang.@Nullable Integer>",
                 info.superClassType().toString());
         info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$Nest1$Nest2$Nest3$1$2.class"));
         assertEquals(
-                "test.TypeParameterBoundExample$Nest1<java.lang.String>.Nest2<@Nullable java.lang.Object[]>.Nest3<java.lang.Integer>",
+                "test.TypeParameterBoundExample$Nest1<java.lang.String>.Nest2<java.lang.@Nullable Object[]>.Nest3<java.lang.Integer>",
                 info.superClassType().toString());
     }
 
@@ -110,7 +110,7 @@ public class TypeParameterBoundTestCase {
 
     private void verifySerializableListConsumerDA(ClassInfo info) {
         assertEquals(
-                "T extends @Nullable @Untainted java.util.List & @Untainted java.io.Serializable",
+                "T extends java.util.@Nullable @Untainted List & java.io.@Untainted Serializable",
                 info.typeParameters().get(0).toString());
 
         List<AnnotationInstance> annotationInstances = info.annotationsMap().get(DotName.createSimple("test.Nullable"));


### PR DESCRIPTION
This includes several things:

- `Type.toString()` no longer shows type annotations before a package name,
  because package names can't be annotated;
- type annotations on types that are local classes are supported properly;
- type annotations on outermost annotable types are supported properly.

Fixes #161.