### PR TITLE
remove the notion of data version

### DIFF
--- a/core/src/main/java/org/jboss/jandex/IndexReader.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReader.java
@@ -94,32 +94,11 @@ public final class IndexReader {
     }
 
     /**
-     * Returns the version of the data contract stored in the index that was read. This version is incremented when
-     * the contract adds new information. Generally this is used to determine if the underlying index contains
-     * necessary information for analysis. As an example, generics are recorded in version 4; therefore, a tool that
-     * requires generic data would need to reject/ignore version 3 data.
-     * <br>
-     * The data contract version should not be confused with the index file version, which represents the internal
-     * storage format of the file. The index file version moves independently of the data contract.
+     * Returns the index file version. This version number marks the internal storage format and also implies
+     * the version of data contract of the index. It is incremented whenever more information are added
+     * to the index format, so it may be used to determine whether an index file contains necessary information.
      *
-     * @return The data contract version of the index that was read
-     * @throws IOException If the index could not be read
-     */
-    public int getDataVersion() throws IOException {
-        if (version == -1) {
-            readVersion();
-        }
-
-        return reader.toDataVersion(version);
-    }
-
-    /**
-     * Returns the index file version. Note that the index file version may increment even though the underlying
-     * data contract remains the same. In most cases, {@link #getDataVersion()} should be used instead of this method,
-     * since applications are typically interested in the underlying contract of the data stored, and not the internal
-     * implementation details of a Jandex index.
-     *
-     * @return the internal index file version
+     * @return the index file version
      * @throws IOException If the index could not be read
      */
     public int getIndexVersion() throws IOException {

--- a/core/src/main/java/org/jboss/jandex/IndexReaderImpl.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderImpl.java
@@ -26,6 +26,4 @@ import java.io.IOException;
  */
 abstract class IndexReaderImpl {
     abstract Index read() throws IOException;
-
-    abstract int toDataVersion(int version);
 }

--- a/core/src/main/java/org/jboss/jandex/IndexReaderV1.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV1.java
@@ -324,10 +324,4 @@ final class IndexReaderV1 extends IndexReaderImpl {
             lastDepth = depth;
         }
     }
-
-    int toDataVersion(int version) {
-        // From 1 to 3, every version changed the available data
-
-        return version;
-    }
 }

--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -50,7 +50,6 @@ import java.util.Set;
 final class IndexReaderV2 extends IndexReaderImpl {
     static final int MIN_VERSION = 6;
     static final int MAX_VERSION = 11;
-    static final int MAX_DATA_VERSION = 4;
     private static final byte NULL_TARGET_TAG = 0;
     private static final byte FIELD_TAG = 1;
     private static final byte METHOD_TAG = 2;
@@ -901,9 +900,5 @@ final class IndexReaderV2 extends IndexReaderImpl {
         }
 
         return modules;
-    }
-
-    int toDataVersion(int version) {
-        return MAX_DATA_VERSION;
     }
 }


### PR DESCRIPTION
The data version number wasn't kept up to date, most likely because
noone even knows there was a difference between index version and
data version. This commit removes the notion of data version and
intentionally conflates the index format version and data version.
It's not like Jandex has ever changed its persistent format without
also changing the data contract...

Resolves #181