### PR TITLE
Fix wrong type parameter sharing in generic signature parser

### DIFF
--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -1658,6 +1658,7 @@ public final class Indexer {
         int end = signatures.size();
 
         // Class signature should be processed first to establish class type parameters
+        signatureParser.beforeNewClass();
         if (classSignatureIndex >= 0) {
             String elementSignature = (String) signatures.get(classSignatureIndex);
             Object element = signatures.get(classSignatureIndex + 1);
@@ -1668,6 +1669,8 @@ public final class Indexer {
             if (i == classSignatureIndex) {
                 continue;
             }
+
+            signatureParser.beforeNewElement();
 
             String elementSignature = (String) signatures.get(i);
             Object element = signatures.get(i + 1);

--- a/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnClassTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnClassTest.java
@@ -9,7 +9,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.Test;
 
-public class SignatureSharingTest {
+public class SignatureSharingOnClassTest {
     public interface WithMethodSignature {
         <E extends Runnable> E method(E arg);
     }

--- a/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnMethodTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnMethodTest.java
@@ -1,0 +1,42 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+
+public class SignatureSharingOnMethodTest {
+    public interface WithClassSignature<E extends Exception> {
+    }
+
+    public interface WithMethodSignature {
+        <E extends Comparable<E>> E method();
+    }
+
+    @Test
+    public void methodSignatureOnly() throws Exception {
+        test(Index.of(WithMethodSignature.class));
+    }
+
+    @Test
+    public void methodSignatureBeforeClassSignature() throws Exception {
+        test(Index.of(WithMethodSignature.class, WithClassSignature.class));
+    }
+
+    @Test
+    public void methodSignatureAfterClassSignature() throws Exception {
+        test(Index.of(WithClassSignature.class, WithMethodSignature.class));
+    }
+
+    private void test(Index index) {
+        ClassInfo clazz = index.getClassByName(WithMethodSignature.class);
+        Type typeVariable = clazz.firstMethod("method").returnType().asTypeVariable() // E extends Comparable<E>
+                .bounds().get(0).asParameterizedType() // Comparable<E>
+                .arguments().get(0); // E
+
+        assertEquals(Type.Kind.UNRESOLVED_TYPE_VARIABLE, typeVariable.kind());
+        assertEquals("E", typeVariable.asUnresolvedTypeVariable().identifier());
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnOwnClassTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/SignatureSharingOnOwnClassTest.java
@@ -1,0 +1,26 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.Type;
+import org.junit.jupiter.api.Test;
+
+public class SignatureSharingOnOwnClassTest {
+    public interface WithSignatures<E extends Runnable> {
+        <E extends Comparable<E>> E method();
+    }
+
+    @Test
+    public void test() throws Exception {
+        Index index = Index.of(WithSignatures.class);
+        ClassInfo clazz = index.getClassByName(WithSignatures.class);
+        Type typeVariable = clazz.firstMethod("method").returnType().asTypeVariable() // E extends Comparable<E>
+                .bounds().get(0).asParameterizedType() // Comparable<E>
+                .arguments().get(0); // E
+
+        assertEquals(Type.Kind.UNRESOLVED_TYPE_VARIABLE, typeVariable.kind());
+        assertEquals("E", typeVariable.asUnresolvedTypeVariable().identifier());
+    }
+}


### PR DESCRIPTION
The generic signature parser used to forget previously encountered
type parameters when parsing a signature of a new element or class.
This leaves a hole: if a previously encountered class did have
a signature but a new class did not, the class-level type parameters
were not forgotten correctly, because no new class signature was
parsed. The previously encountered class-level type parameters must
be forgotten unconditionally, even if the new class has no signature.

Also the generic signature parser used to remember a parsed type
parameter only when it was fully consumed. This is incorrect in case
of a recursive type parameter, where the type parameter's bounds
may refer to the type parameter itself. This requires remembering
the type parameter's existence early, before parsing its bounds.
One way how to remember the type parameter's existence is to simply
remember a `null` type variable under the type parameter's name,
which the rest of the code handles as an unresolved type variable,
and fixing it after the type parameter is fully parsed.