### PR TITLE
Serialize unbounded wildcards faithfully

### DIFF
--- a/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexReaderV2.java
@@ -404,7 +404,7 @@ final class IndexReaderV2 extends IndexReaderImpl {
             }
             case WILDCARD_TYPE: {
                 boolean isExtends = stream.readPackedU32() == 1;
-                Type bound = typeTable[stream.readPackedU32()];
+                Type bound = typeTable[stream.readPackedU32()]; // may be null in case of an unbounded wildcard
                 AnnotationInstance[] annotations = readAnnotations(stream, null);
                 return new WildcardType(bound, isExtends, annotations);
 

--- a/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
+++ b/core/src/main/java/org/jboss/jandex/IndexWriterV2.java
@@ -854,7 +854,8 @@ final class IndexWriterV2 extends IndexWriterImpl {
             case WILDCARD_TYPE:
                 WildcardType wildcardType = type.asWildcardType();
                 stream.writePackedU32(wildcardType.isExtends() ? 1 : 0);
-                writeReference(stream, wildcardType.bound(), false);
+                boolean hasImplicitBound = wildcardType.hasImplicitObjectBound();
+                writeReference(stream, hasImplicitBound ? null : wildcardType.bound(), hasImplicitBound);
                 break;
             case PARAMETERIZED_TYPE:
                 ParameterizedType parameterizedType = type.asParameterizedType();

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -314,10 +314,6 @@ public abstract class Type {
      * @return the string representation.
      */
     public String toString() {
-        return toString(false);
-    }
-
-    String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
         String packagePrefix = name.packagePrefix();
         if (packagePrefix != null) {

--- a/core/src/main/java/org/jboss/jandex/TypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariable.java
@@ -108,17 +108,17 @@ public final class TypeVariable extends Type {
         return this;
     }
 
-    String toString(boolean simple) {
+    @Override
+    public String toString() {
         StringBuilder builder = new StringBuilder();
         appendAnnotations(builder);
         builder.append(name);
 
-        // FIXME - revist this logic
-        if (!simple && bounds.length > 0 && !(bounds.length == 1 && ClassType.OBJECT_TYPE.equals(bounds[0]))) {
-            builder.append(" extends ").append(bounds[0].toString(true));
+        if (bounds.length > 0 && !(bounds.length == 1 && ClassType.OBJECT_TYPE.equals(bounds[0]))) {
+            builder.append(" extends ").append(bounds[0].toString());
 
             for (int i = 1; i < bounds.length; i++) {
-                builder.append(" & ").append(bounds[i].toString(true));
+                builder.append(" & ").append(bounds[i].toString());
             }
         }
 

--- a/core/src/main/java/org/jboss/jandex/UnresolvedTypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/UnresolvedTypeVariable.java
@@ -65,7 +65,10 @@ public final class UnresolvedTypeVariable extends Type {
     }
 
     public String toString() {
-        return name;
+        StringBuilder builder = new StringBuilder();
+        appendAnnotations(builder);
+        builder.append(name);
+        return builder.toString();
     }
 
     @Override

--- a/core/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeParameterBoundTestCase.java
@@ -42,7 +42,7 @@ public class TypeParameterBoundTestCase {
     public void listConsumer() throws IOException {
         ClassInfo info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$ListConsumer.class"));
         assertEquals(
-                "T extends java.util.@Nullable List",
+                "T extends java.util.@Nullable List<?>",
                 info.typeParameters().get(0).toString());
     }
 
@@ -50,7 +50,7 @@ public class TypeParameterBoundTestCase {
     public void arrayListConsumer() throws IOException {
         ClassInfo info = IndexingUtil.indexSingle(getClassBytes("test/TypeParameterBoundExample$ArrayListConsumer.class"));
         assertEquals(
-                "T extends java.util.@Nullable ArrayList",
+                "T extends java.util.@Nullable ArrayList<?>",
                 info.typeParameters().get(0).toString());
     }
 
@@ -59,7 +59,7 @@ public class TypeParameterBoundTestCase {
         ClassInfo info = IndexingUtil
                 .indexSingle(getClassBytes("test/TypeParameterBoundExample$SerializableListConsumer.class"));
         assertEquals(
-                "T extends java.util.@Nullable List & java.io.@Untainted Serializable",
+                "T extends java.util.@Nullable List<?> & java.io.@Untainted Serializable",
                 info.typeParameters().get(0).toString());
     }
 
@@ -110,7 +110,7 @@ public class TypeParameterBoundTestCase {
 
     private void verifySerializableListConsumerDA(ClassInfo info) {
         assertEquals(
-                "T extends java.util.@Nullable @Untainted List & java.io.@Untainted Serializable",
+                "T extends java.util.@Nullable @Untainted List<?> & java.io.@Untainted Serializable",
                 info.typeParameters().get(0).toString());
 
         List<AnnotationInstance> annotationInstances = info.annotationsMap().get(DotName.createSimple("test.Nullable"));

--- a/core/src/test/java/org/jboss/jandex/test/UnboundedWildcardTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/UnboundedWildcardTest.java
@@ -1,0 +1,49 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class UnboundedWildcardTest {
+    private List<?> implicitlyUnboundedWildcard;
+
+    private List<? extends Object> explicitlyUnboundedWildcard;
+
+    private List<@MyAnnotation("wildcard") ?> annotatedImplicitlyUnboundedWildcard;
+
+    private List<@MyAnnotation("wildcard") ? extends @MyAnnotation("bound") Object> annotatedExplicitlyUnboundedWildcard;
+
+    @Test
+    public void test() throws IOException {
+        Index index = Index.of(UnboundedWildcardTest.class);
+        test(index);
+        test(IndexingUtil.roundtrip(index));
+    }
+
+    private void test(Index index) {
+        ClassInfo clazz = index.getClassByName(UnboundedWildcardTest.class);
+
+        FieldInfo implicitlyUnboundedWildcard = clazz.field("implicitlyUnboundedWildcard");
+        assertEquals("java.util.List<?>",
+                implicitlyUnboundedWildcard.type().toString());
+
+        FieldInfo explicitlyUnboundedWildcard = clazz.field("explicitlyUnboundedWildcard");
+        assertEquals("java.util.List<?>",
+                explicitlyUnboundedWildcard.type().toString());
+
+        FieldInfo annotatedImplicitlyUnboundedWildcard = clazz.field("annotatedImplicitlyUnboundedWildcard");
+        assertEquals("java.util.List<@MyAnnotation(\"wildcard\") ?>",
+                annotatedImplicitlyUnboundedWildcard.type().toString());
+
+        FieldInfo annotatedExplicitlyUnboundedWildcard = clazz.field("annotatedExplicitlyUnboundedWildcard");
+        assertEquals("java.util.List<@MyAnnotation(\"wildcard\") ? extends java.lang.@MyAnnotation(\"bound\") Object>",
+                annotatedExplicitlyUnboundedWildcard.type().toString());
+    }
+}


### PR DESCRIPTION
This commit includes regularization of string representation of types,
which is how the unfaithfulness was discovered in the first place.