### PR TITLE
Workaround for wrong type annotations on compact record constructor

### DIFF
--- a/core/src/main/java/org/jboss/jandex/Indexer.java
+++ b/core/src/main/java/org/jboss/jandex/Indexer.java
@@ -827,6 +827,11 @@ public final class Indexer {
             case 0x13: // FIELD
             case 0x14: // METHOD_RETURN
             case 0x15: // METHOD_RECEIVER
+                // javac has a bug in case of compact record constructors, where it targets a type annotation
+                // on a constructor parameter type to a field; in such case, just skip the annotation
+                if (target.kind() == AnnotationTarget.Kind.METHOD && targetType == 0x13) {
+                    break;
+                }
                 typeTarget = new EmptyTypeTarget(target, targetType == 0x15);
                 break;
             case 0x16: // METHOD_FORMAL_PARAMETER

--- a/core/src/test/java/org/jboss/jandex/test/RecordTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/RecordTestCase.java
@@ -75,7 +75,7 @@ public class RecordTestCase {
         assertEquals("name", componentAnnos.get(0).target().asRecordComponent().name());
         assertEquals("nameComponent", componentAnnos.get(0).value().asString());
 
-        assertEquals(3, rec.recordComponents().size());
+        assertEquals(4, rec.recordComponents().size());
 
         RecordComponentInfo idComponent = rec.recordComponent("id");
         assertNotNull(idComponent);

--- a/test-data/src/main/java/test/RecordExample.java
+++ b/test-data/src/main/java/test/RecordExample.java
@@ -4,11 +4,16 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.List;
 
 @RecordExample.RecordAnnotation("Example")
 public record RecordExample<T> (@Nullable Integer id,
         @Nullable @ComponentAnnotation("nameComponent") @FieldAnnotation("nameField") @AccessorAnnotation("nameAccessor") String name,
+        List<@Nullable String> parameterized,
         T generic) {
+
+    public RecordExample {
+    }
 
     static String staticField;
 


### PR DESCRIPTION
It seems javac has a bug when emitting a compact constructor of a record
that declares a component whose type has type annotations. For example:

    public record MyRecord(List<@NotEmpty String> list) {
        public MyRecord {
        }
    }

In this case, javac emits a type annotation whose `target_type` is 0x13
(that is, the type annotation is supposed to target a field). That is wrong.

My guess is that javac simply copies the type from the implicitly declared
component field, together with type annotations, into the implicitly declared
parameter list of the compact constructor. (On the other hand, type annotations
on the implicitly declared accessor methods are correct.)

With this commit, Jandex ignores such erroneous type annotations.

Fixes #218