### PR TITLE
Propagate type annotations on all type variables + improve Type.toString()

### DIFF
--- a/core/src/main/java/org/jboss/jandex/ArrayType.java
+++ b/core/src/main/java/org/jboss/jandex/ArrayType.java
@@ -92,20 +92,21 @@ public final class ArrayType extends Type {
         return DotName.createSimple(builder.toString());
     }
 
-    public String toString() {
+    @Override
+    String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
 
-        appendRootComponent(builder);
+        appendRootComponent(builder, true);
         appendArraySyntax(builder);
 
         return builder.toString();
     }
 
-    private void appendRootComponent(StringBuilder builder) {
+    private void appendRootComponent(StringBuilder builder, boolean simple) {
         if (component.kind() == Kind.ARRAY) {
-            component.asArrayType().appendRootComponent(builder);
+            component.asArrayType().appendRootComponent(builder, simple);
         } else {
-            builder.append(component);
+            builder.append(component.toString(simple));
         }
     }
 

--- a/core/src/main/java/org/jboss/jandex/FieldInfo.java
+++ b/core/src/main/java/org/jboss/jandex/FieldInfo.java
@@ -367,7 +367,7 @@ public final class FieldInfo implements AnnotationTarget {
      * Returns a string representation describing this field. It is similar although not necessarily equivalent
      * to a Java source code expression representing this field.
      *
-     * @return a string representation for this field
+     * @return a string representation of this field
      */
     public String toString() {
         return internal.toString(clazz);

--- a/core/src/main/java/org/jboss/jandex/FieldInternal.java
+++ b/core/src/main/java/org/jboss/jandex/FieldInternal.java
@@ -136,11 +136,11 @@ final class FieldInternal {
 
     @Override
     public String toString() {
-        return type + " " + name();
+        return type.toString(true) + " " + name();
     }
 
     public String toString(ClassInfo clazz) {
-        return type + " " + clazz.name() + "." + name();
+        return type.toString(true) + " " + clazz.name() + "." + name();
     }
 
     void setType(Type type) {

--- a/core/src/main/java/org/jboss/jandex/MethodInfo.java
+++ b/core/src/main/java/org/jboss/jandex/MethodInfo.java
@@ -154,7 +154,7 @@ public final class MethodInfo implements AnnotationTarget {
     /**
      * Returns the name of the given parameter.
      *
-     * @param i the parameter index
+     * @param i the parameter index, zero-based
      * @return the name of the given parameter, or {@code null} if not known
      */
     public final String parameterName(int i) {
@@ -164,7 +164,7 @@ public final class MethodInfo implements AnnotationTarget {
     /**
      * Returns the type of the given parameter.
      *
-     * @param i the parameter index
+     * @param i the parameter index, zero-based
      * @return the type of the given parameter
      */
     public final Type parameterType(int i) {

--- a/core/src/main/java/org/jboss/jandex/ParameterizedType.java
+++ b/core/src/main/java/org/jboss/jandex/ParameterizedType.java
@@ -131,7 +131,8 @@ public class ParameterizedType extends Type {
         return this;
     }
 
-    public String toString() {
+    @Override
+    String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
 
         if (owner != null) {
@@ -150,9 +151,9 @@ public class ParameterizedType extends Type {
 
         if (arguments.length > 0) {
             builder.append('<');
-            builder.append(arguments[0]);
+            builder.append(arguments[0].toString(true));
             for (int i = 1; i < arguments.length; i++) {
-                builder.append(", ").append(arguments[i]);
+                builder.append(", ").append(arguments[i].toString(true));
             }
             builder.append('>');
         }
@@ -165,8 +166,18 @@ public class ParameterizedType extends Type {
         return new ParameterizedType(name(), arguments, owner, newAnnotations);
     }
 
-    ParameterizedType copyType(Type[] parameters) {
-        return new ParameterizedType(name(), parameters, owner, annotationArray());
+    ParameterizedType copyType(Type[] arguments) {
+        return new ParameterizedType(name(), arguments, owner, annotationArray());
+    }
+
+    ParameterizedType copyType(int argumentIndex, Type argument) {
+        if (argumentIndex > this.arguments.length) {
+            throw new IllegalArgumentException("Type argument index outside of bounds");
+        }
+
+        Type[] arguments = this.arguments.clone();
+        arguments[argumentIndex] = argument;
+        return new ParameterizedType(name(), arguments, owner, annotationArray());
     }
 
     ParameterizedType copyType(Type owner) {

--- a/core/src/main/java/org/jboss/jandex/RecordComponentInfo.java
+++ b/core/src/main/java/org/jboss/jandex/RecordComponentInfo.java
@@ -324,7 +324,7 @@ public final class RecordComponentInfo implements AnnotationTarget {
      * @return a string representation of this record component
      */
     public String toString() {
-        return name();
+        return internal.toString(clazz);
     }
 
     @Override

--- a/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
+++ b/core/src/main/java/org/jboss/jandex/RecordComponentInternal.java
@@ -123,11 +123,11 @@ final class RecordComponentInternal {
 
     @Override
     public String toString() {
-        return type + " " + name();
+        return type.toString(true) + " " + name();
     }
 
     public String toString(ClassInfo clazz) {
-        return type + " " + clazz.name() + "." + name();
+        return type.toString(true) + " " + clazz.name() + "." + name();
     }
 
     void setType(Type type) {

--- a/core/src/main/java/org/jboss/jandex/Type.java
+++ b/core/src/main/java/org/jboss/jandex/Type.java
@@ -314,6 +314,10 @@ public abstract class Type {
      * @return the string representation.
      */
     public String toString() {
+        return toString(false);
+    }
+
+    String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
         String packagePrefix = name.packagePrefix();
         if (packagePrefix != null) {

--- a/core/src/main/java/org/jboss/jandex/TypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/TypeVariable.java
@@ -40,7 +40,7 @@ import java.util.List;
 public final class TypeVariable extends Type {
     // The lower 31 bits represents the hash code
     private static final int HASH_MASK = Integer.MAX_VALUE;
-    // The high bit represents the implicit object flag
+    // The high bit represents the implicit object bound flag
     private static final int IMPLICIT_MASK = Integer.MIN_VALUE;
     private final String name;
     private final Type[] bounds;
@@ -109,16 +109,16 @@ public final class TypeVariable extends Type {
     }
 
     @Override
-    public String toString() {
+    String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
         appendAnnotations(builder);
         builder.append(name);
 
-        if (bounds.length > 0 && !(bounds.length == 1 && ClassType.OBJECT_TYPE.equals(bounds[0]))) {
-            builder.append(" extends ").append(bounds[0].toString());
+        if (!simple && bounds.length > 0 && !(bounds.length == 1 && ClassType.OBJECT_TYPE.equals(bounds[0]))) {
+            builder.append(" extends ").append(bounds[0].toString(true));
 
             for (int i = 1; i < bounds.length; i++) {
-                builder.append(" & ").append(bounds[i].toString());
+                builder.append(" & ").append(bounds[i].toString(true));
             }
         }
 

--- a/core/src/main/java/org/jboss/jandex/UnresolvedTypeVariable.java
+++ b/core/src/main/java/org/jboss/jandex/UnresolvedTypeVariable.java
@@ -64,7 +64,8 @@ public final class UnresolvedTypeVariable extends Type {
         return this;
     }
 
-    public String toString() {
+    @Override
+    String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
         appendAnnotations(builder);
         builder.append(name);

--- a/core/src/main/java/org/jboss/jandex/WildcardType.java
+++ b/core/src/main/java/org/jboss/jandex/WildcardType.java
@@ -102,17 +102,18 @@ public class WildcardType extends Type {
         return this;
     }
 
-    public String toString() {
+    @Override
+    String toString(boolean simple) {
         StringBuilder builder = new StringBuilder();
         appendAnnotations(builder);
         builder.append('?');
 
         if (isExtends && bound != OBJECT) {
-            builder.append(" extends ").append(bound);
+            builder.append(" extends ").append(bound.toString(true));
         }
 
         if (!isExtends && bound != null) {
-            builder.append(" super ").append(bound);
+            builder.append(" super ").append(bound.toString(true));
         }
 
         return builder.toString();

--- a/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/BasicTestCase.java
@@ -75,18 +75,15 @@ import org.junit.jupiter.api.Test;
 public class BasicTestCase {
     @Retention(RetentionPolicy.RUNTIME)
     public @interface FieldAnnotation {
-
     }
 
     @Retention(RetentionPolicy.RUNTIME)
     public @interface ParameterAnnotation {
-
     }
 
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.TYPE_PARAMETER, ElementType.TYPE_USE })
     public @interface TypeUseAnnotation {
-
     }
 
     @Retention(RetentionPolicy.RUNTIME)

--- a/core/src/test/java/org/jboss/jandex/test/TransitiveTypeParameterBoundsTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TransitiveTypeParameterBoundsTest.java
@@ -20,197 +20,197 @@ import org.jboss.jandex.TypeVariable;
 import org.jboss.jandex.test.util.IndexingUtil;
 import org.junit.jupiter.api.Test;
 
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann1 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann2 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann3 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann4 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann5 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann6 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann7 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann8 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann9 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann10 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann11 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann12 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann13 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann14 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann15 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann16 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann17 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann18 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann19 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann20 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann21 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann22 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann23 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann24 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann25 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann26 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann27 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann28 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann29 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann30 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann31 {
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@Target(ElementType.TYPE_USE)
-@interface Ann32 {
-}
-
-class ClassWithTransitiveTypeParameterBounds<@Ann1 A extends @Ann2 Number, @Ann3 B extends @Ann4 A, @Ann5 C extends @Ann6 B> {
-    <@Ann7 D extends @Ann8 C, @Ann9 E extends @Ann10 D> Class<?> method() {
-        class LocalClass<@Ann11 F extends @Ann12 E> {
-            <@Ann13 G extends @Ann14 F> void localMethod() {
-            }
-        }
-
-        return LocalClass.class;
-    }
-
-    class InnerClass<@Ann15 H extends @Ann16 C> {
-        <@Ann17 I extends @Ann18 H> void innerMethod() {
-        }
-
-        class InnerInnerClass<@Ann19 J extends @Ann20 C> {
-            <@Ann21 K extends @Ann22 C> void innerInnerMethod() {
-            }
-        }
-    }
-
-    static class NestedClass<@Ann23 A extends @Ann24 Number, @Ann25 B extends @Ann26 A> {
-    }
-
-    static <@Ann27 A extends @Ann28 Number, @Ann29 B extends @Ann30 A> Class<?> staticMethod() {
-        class StaticLocalClass<@Ann31 C extends @Ann32 B> {
-        }
-        return StaticLocalClass.class;
-    }
-}
-
 public class TransitiveTypeParameterBoundsTest {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann1 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann2 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann3 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann4 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann5 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann6 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann7 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann8 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann9 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann10 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann11 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann12 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann13 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann14 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann15 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann16 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann17 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann18 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann19 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann20 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann21 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann22 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann23 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann24 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann25 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann26 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann27 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann28 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann29 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann30 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann31 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann32 {
+    }
+
+    static class ClassWithTransitiveTypeParameterBounds<@Ann1 A extends @Ann2 Number, @Ann3 B extends @Ann4 A, @Ann5 C extends @Ann6 B> {
+        <@Ann7 D extends @Ann8 C, @Ann9 E extends @Ann10 D> Class<?> method() {
+            class LocalClass<@Ann11 F extends @Ann12 E> {
+                <@Ann13 G extends @Ann14 F> void localMethod() {
+                }
+            }
+
+            return LocalClass.class;
+        }
+
+        class InnerClass<@Ann15 H extends @Ann16 C> {
+            <@Ann17 I extends @Ann18 H> void innerMethod() {
+            }
+
+            class InnerInnerClass<@Ann19 J extends @Ann20 C> {
+                <@Ann21 K extends @Ann22 C> void innerInnerMethod() {
+                }
+            }
+        }
+
+        static class NestedClass<@Ann23 A extends @Ann24 Number, @Ann25 B extends @Ann26 A> {
+        }
+
+        static <@Ann27 A extends @Ann28 Number, @Ann29 B extends @Ann30 A> Class<?> staticMethod() {
+            class StaticLocalClass<@Ann31 C extends @Ann32 B> {
+            }
+            return StaticLocalClass.class;
+        }
+    }
+
     @Test
     public void test() throws IOException {
         @SuppressWarnings("rawtypes")

--- a/core/src/test/java/org/jboss/jandex/test/TransitiveTypeVariablesTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TransitiveTypeVariablesTest.java
@@ -1,0 +1,426 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.TypeVariable;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class TransitiveTypeVariablesTest {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann1 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann2 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann3 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann4 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann5 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann6 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann7 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann8 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann9 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann10 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann11 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann12 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann13 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann14 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann15 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann16 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann17 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann18 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann19 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann20 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann21 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann22 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann23 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann24 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann25 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann26 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann27 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann28 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann29 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann30 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann31 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann32 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann33 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann34 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann35 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann36 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann37 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann38 {
+    }
+
+    interface TestInterface<T> {
+    }
+
+    static class TestClass<@Ann1 A extends @Ann2 Exception, @Ann3 B extends @Ann4 A, @Ann5 C extends @Ann6 B>
+            extends @Ann7 ArrayList<@Ann8 C> implements @Ann9 TestInterface<@Ann10 B> {
+
+        @Ann11
+        C field1;
+
+        @Ann12
+        List<@Ann13 ? extends @Ann14 C> field2;
+
+        @Ann15
+        C[] @Ann16 [] field3;
+
+        <@Ann17 D extends @Ann18 C, @Ann19 E extends @Ann20 D> @Ann21 List<@Ann22 E> method(
+                @Ann23 TestClass<@Ann24 A, @Ann25 B, @Ann26 C> this,
+                @Ann27 E[] @Ann28 [] param1,
+                @Ann29 List<@Ann30 ? super @Ann31 E> param2)
+                throws @Ann32 D {
+            return null;
+        }
+
+        class InnerClass<@Ann33 F extends @Ann34 C, @Ann35 G extends @Ann36 F> implements TestInterface<@Ann37 G> {
+            @Ann38
+            G field;
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+        Index index = Index.of(TestClass.class, TestClass.InnerClass.class);
+        test(index);
+        test(IndexingUtil.roundtrip(index));
+    }
+
+    private void test(Index index) {
+        ClassInfo clazz = index.getClassByName(TestClass.class);
+        assertNotNull(clazz);
+        assertEquals(3, clazz.typeParameters().size());
+        assertA(clazz.typeParameters().get(0), Ann1.class);
+        assertB(clazz.typeParameters().get(1), Ann3.class);
+        assertC(clazz.typeParameters().get(2), Ann5.class);
+
+        Type superClass = clazz.superClassType();
+        assertNotNull(superClass);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, superClass.kind());
+        assertEquals(DotName.createSimple(ArrayList.class.getName()), superClass.name());
+        assertEquals(1, superClass.asParameterizedType().arguments().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, superClass.asParameterizedType().arguments().get(0).kind());
+        assertTrue(superClass.hasAnnotation(DotName.createSimple(Ann7.class.getName())));
+        assertC(superClass.asParameterizedType().arguments().get(0).asTypeVariable(), Ann8.class);
+
+        assertEquals(1, clazz.interfaceTypes().size());
+        Type superInterface = clazz.interfaceTypes().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, superInterface.kind());
+        assertEquals(DotName.createSimple(TestInterface.class.getName()), superInterface.name());
+        assertEquals(1, superInterface.asParameterizedType().arguments().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, superInterface.asParameterizedType().arguments().get(0).kind());
+        assertTrue(superInterface.hasAnnotation(DotName.createSimple(Ann9.class.getName())));
+        assertB(superInterface.asParameterizedType().arguments().get(0).asTypeVariable(), Ann10.class);
+
+        FieldInfo field1 = clazz.field("field1");
+        assertNotNull(field1);
+        assertEquals(Type.Kind.TYPE_VARIABLE, field1.type().kind());
+        assertC(field1.type().asTypeVariable(), Ann11.class);
+
+        FieldInfo field2 = clazz.field("field2");
+        assertNotNull(field2);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, field2.type().kind());
+        assertEquals(DotName.createSimple(List.class.getName()), field2.type().asParameterizedType().name());
+        assertEquals(1, field2.type().asParameterizedType().arguments().size());
+        assertEquals(Type.Kind.WILDCARD_TYPE, field2.type().asParameterizedType().arguments().get(0).kind());
+        assertEquals(Type.Kind.TYPE_VARIABLE,
+                field2.type().asParameterizedType().arguments().get(0).asWildcardType().extendsBound().kind());
+        assertTrue(field2.type().hasAnnotation(DotName.createSimple(Ann12.class.getName())));
+        assertTrue(field2.type().asParameterizedType().arguments().get(0)
+                .hasAnnotation(DotName.createSimple(Ann13.class.getName())));
+        assertC(field2.type().asParameterizedType().arguments().get(0).asWildcardType().extendsBound().asTypeVariable(),
+                Ann14.class);
+
+        FieldInfo field3 = clazz.field("field3");
+        assertNotNull(field3);
+        assertEquals(Type.Kind.ARRAY, field3.type().kind());
+        assertEquals(Type.Kind.ARRAY, field3.type().asArrayType().component().kind());
+        assertEquals(Type.Kind.TYPE_VARIABLE, field3.type().asArrayType().component().asArrayType().component().kind());
+        assertTrue(field3.type().annotations().isEmpty());
+        assertTrue(field3.type().asArrayType().component().hasAnnotation(DotName.createSimple(Ann16.class.getName())));
+        assertC(field3.type().asArrayType().component().asArrayType().component().asTypeVariable(), Ann15.class);
+
+        MethodInfo method = clazz.firstMethod("method");
+        assertNotNull(method);
+        assertEquals(2, method.typeParameters().size());
+        assertD(method.typeParameters().get(0), Ann17.class);
+        assertE(method.typeParameters().get(1), Ann19.class);
+
+        Type receiver = method.receiverType();
+        assertNotNull(receiver);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, receiver.kind());
+        assertEquals(3, receiver.asParameterizedType().arguments().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, receiver.asParameterizedType().arguments().get(0).kind());
+        assertEquals(Type.Kind.TYPE_VARIABLE, receiver.asParameterizedType().arguments().get(1).kind());
+        assertEquals(Type.Kind.TYPE_VARIABLE, receiver.asParameterizedType().arguments().get(2).kind());
+        assertTrue(receiver.hasAnnotation(DotName.createSimple(Ann23.class.getName())));
+        assertA(receiver.asParameterizedType().arguments().get(0).asTypeVariable(), Ann24.class);
+        assertB(receiver.asParameterizedType().arguments().get(1).asTypeVariable(), Ann25.class);
+        assertC(receiver.asParameterizedType().arguments().get(2).asTypeVariable(), Ann26.class);
+
+        assertEquals(2, method.parametersCount());
+
+        Type param1 = method.parameterType(0);
+        assertEquals(Type.Kind.ARRAY, param1.kind());
+        assertEquals(Type.Kind.ARRAY, param1.asArrayType().component().kind());
+        assertEquals(Type.Kind.TYPE_VARIABLE, param1.asArrayType().component().asArrayType().component().kind());
+        assertTrue(param1.annotations().isEmpty());
+        assertTrue(param1.asArrayType().component().hasAnnotation(DotName.createSimple(Ann28.class.getName())));
+        assertE(param1.asArrayType().component().asArrayType().component().asTypeVariable(), Ann27.class);
+
+        Type param2 = method.parameterType(1);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, param2.kind());
+        assertEquals(1, param2.asParameterizedType().arguments().size());
+        assertEquals(Type.Kind.WILDCARD_TYPE, param2.asParameterizedType().arguments().get(0).kind());
+        assertNotNull(param2.asParameterizedType().arguments().get(0).asWildcardType().superBound());
+        assertEquals(Type.Kind.TYPE_VARIABLE,
+                param2.asParameterizedType().arguments().get(0).asWildcardType().superBound().kind());
+        assertTrue(param2.hasAnnotation(DotName.createSimple(Ann29.class.getName())));
+        assertTrue(param2.asParameterizedType().arguments().get(0).hasAnnotation(DotName.createSimple(Ann30.class.getName())));
+        assertE(param2.asParameterizedType().arguments().get(0).asWildcardType().superBound().asTypeVariable(), Ann31.class);
+
+        assertEquals(1, method.exceptions().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, method.exceptions().get(0).kind());
+        assertD(method.exceptions().get(0).asTypeVariable(), Ann32.class);
+
+        ClassInfo inner = index.getClassByName(TestClass.InnerClass.class);
+        assertNotNull(inner);
+        assertEquals(2, inner.typeParameters().size());
+        assertF(inner.typeParameters().get(0), Ann33.class);
+        assertG(inner.typeParameters().get(1), Ann35.class);
+
+        assertEquals(1, inner.interfaceTypes().size());
+        Type innerSuperInterface = inner.interfaceTypes().get(0);
+        assertEquals(Type.Kind.PARAMETERIZED_TYPE, innerSuperInterface.kind());
+        assertEquals(DotName.createSimple(TestInterface.class.getName()), innerSuperInterface.name());
+        assertEquals(1, innerSuperInterface.asParameterizedType().arguments().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, innerSuperInterface.asParameterizedType().arguments().get(0).kind());
+        assertG(innerSuperInterface.asParameterizedType().arguments().get(0).asTypeVariable(), Ann37.class);
+
+        FieldInfo innerField = inner.field("field");
+        assertNotNull(innerField);
+        assertEquals(Type.Kind.TYPE_VARIABLE, innerField.type().kind());
+        assertG(innerField.type().asTypeVariable(), Ann38.class);
+    }
+
+    private static void assertA(TypeVariable a, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("A", a.identifier());
+        assertTrue(a.hasAnnotation(DotName.createSimple(expectedAnnotation.getName())));
+        assertEquals(1, a.bounds().size());
+        assertEquals(Type.Kind.CLASS, a.bounds().get(0).kind());
+        assertEquals("java.lang.Exception", a.bounds().get(0).asClassType().name().toString());
+        assertTrue(a.bounds().get(0).hasAnnotation(DotName.createSimple(Ann2.class.getName())));
+    }
+
+    private static void assertB(TypeVariable b, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("B", b.identifier());
+        assertTrue(b.hasAnnotation(DotName.createSimple(expectedAnnotation.getName())));
+        assertEquals(1, b.bounds().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, b.bounds().get(0).kind());
+        assertA(b.bounds().get(0).asTypeVariable(), Ann4.class);
+    }
+
+    private static void assertC(TypeVariable c, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("C", c.identifier());
+        assertTrue(c.hasAnnotation(DotName.createSimple(expectedAnnotation.getName())));
+        assertEquals(1, c.bounds().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, c.bounds().get(0).kind());
+        assertB(c.bounds().get(0).asTypeVariable(), Ann6.class);
+    }
+
+    private static void assertD(TypeVariable d, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("D", d.identifier());
+        assertTrue(d.hasAnnotation(DotName.createSimple(expectedAnnotation.getName())));
+        assertEquals(1, d.bounds().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, d.bounds().get(0).kind());
+        assertC(d.bounds().get(0).asTypeVariable(), Ann18.class);
+    }
+
+    private static void assertE(TypeVariable e, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("E", e.identifier());
+        assertTrue(e.hasAnnotation(DotName.createSimple(expectedAnnotation.getName())));
+        assertEquals(1, e.bounds().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, e.bounds().get(0).kind());
+        assertD(e.bounds().get(0).asTypeVariable(), Ann20.class);
+    }
+
+    private static void assertF(TypeVariable f, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("F", f.identifier());
+        assertTrue(f.hasAnnotation(DotName.createSimple(expectedAnnotation.getName())));
+        assertEquals(1, f.bounds().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, f.bounds().get(0).kind());
+        assertC(f.bounds().get(0).asTypeVariable(), Ann34.class);
+    }
+
+    private static void assertG(TypeVariable g, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("G", g.identifier());
+        assertTrue(g.hasAnnotation(DotName.createSimple(expectedAnnotation.getName())));
+        assertEquals(1, g.bounds().size());
+        assertEquals(Type.Kind.TYPE_VARIABLE, g.bounds().get(0).kind());
+        assertF(g.bounds().get(0).asTypeVariable(), Ann36.class);
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeAnnotationTestCase.java
@@ -168,7 +168,7 @@ public class TypeAnnotationTestCase {
         assertEquals("R", type.asTypeVariable().identifier());
         assertEquals(0, type.annotations().size());
         type = type.asTypeVariable().bounds().get(0);
-        assertEquals(0, type.annotations().size());
+        verifyHasAnnotation(nestName(referenceClass, "H"), type);
         assertEquals(Type.Kind.TYPE_VARIABLE, type.kind());
         assertEquals("SU", type.asTypeVariable().identifier());
         type = type.asTypeVariable().bounds().get(0);

--- a/core/src/test/java/org/jboss/jandex/test/TypeToStringTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeToStringTest.java
@@ -1,0 +1,163 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class TypeToStringTest {
+    interface TestInterface<T> {
+    }
+
+    static class TestClass<A extends Exception, B extends A, C extends B>
+            extends ArrayList<C> implements TestInterface<B> {
+
+        C field1;
+
+        List<? extends C> field2;
+
+        C[][] field3;
+
+        <D extends C, E extends D> List<E> method(TestClass<A, B, C> this, E[][] param1, List<? super E> param2) throws D {
+            return null;
+        }
+
+        class InnerClass<F extends C, G extends F> implements TestInterface<G> {
+            G field;
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+        Index index = Index.of(TestClass.class, TestClass.InnerClass.class);
+        test(index);
+        test(IndexingUtil.roundtrip(index));
+    }
+
+    private void test(Index index) {
+        ClassInfo clazz = index.getClassByName(TestClass.class);
+        assertNotNull(clazz);
+        assertEquals(3, clazz.typeParameters().size());
+        assertA(clazz.typeParameters().get(0));
+        assertB(clazz.typeParameters().get(1));
+        assertC(clazz.typeParameters().get(2));
+
+        Type superClass = clazz.superClassType();
+        assertEquals("java.util.ArrayList<C>", superClass.toString());
+        assertC(superClass.asParameterizedType().arguments().get(0));
+
+        assertEquals(1, clazz.interfaceTypes().size());
+        Type superInterface = clazz.interfaceTypes().get(0);
+        assertEquals("org.jboss.jandex.test.TypeToStringTest$TestInterface<B>", superInterface.toString());
+        assertB(superInterface.asParameterizedType().arguments().get(0));
+
+        FieldInfo field1 = clazz.field("field1");
+        assertNotNull(field1);
+        assertEquals("C org.jboss.jandex.test.TypeToStringTest$TestClass.field1", field1.toString());
+        assertC(field1.type());
+
+        FieldInfo field2 = clazz.field("field2");
+        assertNotNull(field2);
+        assertEquals("java.util.List<? extends C> org.jboss.jandex.test.TypeToStringTest$TestClass.field2", field2.toString());
+        assertEquals("java.util.List<? extends C>", field2.type().toString());
+        assertEquals("? extends C", field2.type().asParameterizedType().arguments().get(0).toString());
+        assertC(field2.type().asParameterizedType().arguments().get(0).asWildcardType().extendsBound());
+
+        FieldInfo field3 = clazz.field("field3");
+        assertNotNull(field3);
+        assertEquals("C[][] org.jboss.jandex.test.TypeToStringTest$TestClass.field3", field3.toString());
+        assertEquals("C[][]", field3.type().toString());
+        assertC(field3.type().asArrayType().component());
+
+        MethodInfo method = clazz.firstMethod("method");
+        assertNotNull(method);
+        assertEquals("java.util.List<E> method(E[][] param1, java.util.List<? super E> param2) throws D", method.toString());
+
+        assertEquals(2, method.typeParameters().size());
+        assertD(method.typeParameters().get(0));
+        assertE(method.typeParameters().get(1));
+
+        Type returnType = method.returnType();
+        assertNotNull(returnType);
+        assertEquals("java.util.List<E>", returnType.toString());
+        assertE(returnType.asParameterizedType().arguments().get(0));
+
+        Type receiver = method.receiverType();
+        assertNotNull(receiver);
+        assertEquals("org.jboss.jandex.test.TypeToStringTest$TestClass<A, B, C>", receiver.toString());
+        assertA(receiver.asParameterizedType().arguments().get(0));
+        assertB(receiver.asParameterizedType().arguments().get(1));
+        assertC(receiver.asParameterizedType().arguments().get(2));
+
+        assertEquals(2, method.parametersCount());
+        assertEquals("E[][]", method.parameterType(0).toString());
+        assertE(method.parameterType(0).asArrayType().component());
+        assertEquals("java.util.List<? super E>", method.parameterType(1).toString());
+        assertEquals("? super E", method.parameterType(1).asParameterizedType().arguments().get(0).toString());
+        assertE(method.parameterType(1).asParameterizedType().arguments().get(0).asWildcardType().superBound());
+
+        assertEquals(1, method.exceptions().size());
+        assertD(method.exceptions().get(0));
+
+        ClassInfo inner = index.getClassByName(TestClass.InnerClass.class);
+        assertNotNull(inner);
+        assertEquals(2, inner.typeParameters().size());
+        assertF(inner.typeParameters().get(0));
+        assertG(inner.typeParameters().get(1));
+
+        assertEquals(1, inner.interfaceTypes().size());
+        Type innerSuperInterface = inner.interfaceTypes().get(0);
+        assertEquals("org.jboss.jandex.test.TypeToStringTest$TestInterface<G>", innerSuperInterface.toString());
+        assertG(innerSuperInterface.asParameterizedType().arguments().get(0).asTypeVariable());
+
+        FieldInfo innerField = inner.field("field");
+        assertNotNull(innerField);
+        assertEquals("G org.jboss.jandex.test.TypeToStringTest$TestClass$InnerClass.field", innerField.toString());
+        assertEquals("G extends F", innerField.type().toString());
+        assertG(innerField.type().asTypeVariable());
+    }
+
+    private void assertA(Type a) {
+        assertEquals("A extends java.lang.Exception", a.toString());
+    }
+
+    private void assertB(Type b) {
+        assertEquals("B extends A", b.toString());
+        assertA(b.asTypeVariable().bounds().get(0));
+    }
+
+    private void assertC(Type c) {
+        assertEquals("C extends B", c.toString());
+        assertB(c.asTypeVariable().bounds().get(0));
+    }
+
+    private void assertD(Type d) {
+        assertEquals("D extends C", d.toString());
+        assertC(d.asTypeVariable().bounds().get(0));
+    }
+
+    private void assertE(Type e) {
+        assertEquals("E extends D", e.toString());
+        assertD(e.asTypeVariable().bounds().get(0));
+    }
+
+    private void assertF(Type f) {
+        assertEquals("F extends C", f.toString());
+        assertC(f.asTypeVariable().bounds().get(0));
+    }
+
+    private void assertG(Type g) {
+        assertEquals("G extends F", g.toString());
+        assertF(g.asTypeVariable().bounds().get(0));
+    }
+}

--- a/core/src/test/java/org/jboss/jandex/test/TypeToStringWithAnnotationsTest.java
+++ b/core/src/test/java/org/jboss/jandex/test/TypeToStringWithAnnotationsTest.java
@@ -1,0 +1,382 @@
+package org.jboss.jandex.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.FieldInfo;
+import org.jboss.jandex.Index;
+import org.jboss.jandex.MethodInfo;
+import org.jboss.jandex.Type;
+import org.jboss.jandex.test.util.IndexingUtil;
+import org.junit.jupiter.api.Test;
+
+public class TypeToStringWithAnnotationsTest {
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann1 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann2 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann3 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann4 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann5 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann6 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann7 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann8 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann9 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann10 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann11 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann12 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann13 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann14 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann15 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann16 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann17 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann18 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann19 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann20 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann21 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann22 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann23 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann24 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann25 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann26 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann27 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann28 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann29 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann30 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann31 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann32 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann33 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann34 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann35 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann36 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann37 {
+    }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target(ElementType.TYPE_USE)
+    @interface Ann38 {
+    }
+
+    interface TestInterface<T> {
+    }
+
+    static class TestClass<@Ann1 A extends @Ann2 Exception, @Ann3 B extends @Ann4 A, @Ann5 C extends @Ann6 B>
+            extends @Ann7 ArrayList<@Ann8 C> implements @Ann9 TestInterface<@Ann10 B> {
+
+        @Ann11
+        C field1;
+
+        @Ann12
+        List<@Ann13 ? extends @Ann14 C> field2;
+
+        @Ann15
+        C[] @Ann16 [] field3;
+
+        <@Ann17 D extends @Ann18 C, @Ann19 E extends @Ann20 D> @Ann21 List<@Ann22 E> method(
+                @Ann23 TestClass<@Ann24 A, @Ann25 B, @Ann26 C> this,
+                @Ann27 E[] @Ann28 [] param1,
+                @Ann29 List<@Ann30 ? super @Ann31 E> param2)
+                throws @Ann32 D {
+            return null;
+        }
+
+        class InnerClass<@Ann33 F extends @Ann34 C, @Ann35 G extends @Ann36 F> implements TestInterface<@Ann37 G> {
+            @Ann38
+            G field;
+        }
+    }
+
+    @Test
+    public void test() throws IOException {
+        Index index = Index.of(TestClass.class, TestClass.InnerClass.class);
+        test(index);
+        test(IndexingUtil.roundtrip(index));
+    }
+
+    private void test(Index index) {
+        ClassInfo clazz = index.getClassByName(TestClass.class);
+        assertNotNull(clazz);
+        assertEquals(3, clazz.typeParameters().size());
+        assertA(clazz.typeParameters().get(0), Ann1.class);
+        assertB(clazz.typeParameters().get(1), Ann3.class);
+        assertC(clazz.typeParameters().get(2), Ann5.class);
+
+        Type superClass = clazz.superClassType();
+        assertEquals("java.util.@Ann7 ArrayList<@Ann8 C>", superClass.toString());
+        assertC(superClass.asParameterizedType().arguments().get(0), Ann8.class);
+
+        assertEquals(1, clazz.interfaceTypes().size());
+        Type superInterface = clazz.interfaceTypes().get(0);
+        assertEquals(
+                "org.jboss.jandex.test.@Ann9 TypeToStringWithAnnotationsTest$TestInterface<@Ann10 B>",
+                superInterface.toString());
+        assertB(superInterface.asParameterizedType().arguments().get(0), Ann10.class);
+
+        FieldInfo field1 = clazz.field("field1");
+        assertNotNull(field1);
+        assertEquals("@Ann11 C org.jboss.jandex.test.TypeToStringWithAnnotationsTest$TestClass.field1", field1.toString());
+        assertC(field1.type(), Ann11.class);
+
+        FieldInfo field2 = clazz.field("field2");
+        assertNotNull(field2);
+        assertEquals(
+                "java.util.@Ann12 List<@Ann13 ? extends @Ann14 C> org.jboss.jandex.test.TypeToStringWithAnnotationsTest$TestClass.field2",
+                field2.toString());
+        assertEquals("java.util.@Ann12 List<@Ann13 ? extends @Ann14 C>", field2.type().toString());
+        assertEquals("@Ann13 ? extends @Ann14 C", field2.type().asParameterizedType().arguments().get(0).toString());
+        assertC(field2.type().asParameterizedType().arguments().get(0).asWildcardType().extendsBound(), Ann14.class);
+
+        FieldInfo field3 = clazz.field("field3");
+        assertNotNull(field3);
+        assertEquals(
+                "@Ann15 C[] @Ann16 [] org.jboss.jandex.test.TypeToStringWithAnnotationsTest$TestClass.field3",
+                field3.toString());
+        assertEquals("@Ann15 C[] @Ann16 []", field3.type().toString());
+        assertEquals("@Ann15 C @Ann16 []", field3.type().asArrayType().component().toString());
+        assertC(field3.type().asArrayType().component().asArrayType().component(), Ann15.class);
+
+        MethodInfo method = clazz.firstMethod("method");
+        assertNotNull(method);
+        assertEquals(
+                "java.util.@Ann21 List<@Ann22 E> method(org.jboss.jandex.test.@Ann23 TypeToStringWithAnnotationsTest$TestClass<@Ann24 A, @Ann25 B, @Ann26 C> this, @Ann27 E[] @Ann28 [] param1, java.util.@Ann29 List<@Ann30 ? super @Ann31 E> param2) throws @Ann32 D",
+                method.toString());
+
+        assertEquals(2, method.typeParameters().size());
+        assertD(method.typeParameters().get(0), Ann17.class);
+        assertE(method.typeParameters().get(1), Ann19.class);
+
+        Type returnType = method.returnType();
+        assertNotNull(returnType);
+        assertEquals("java.util.@Ann21 List<@Ann22 E>", returnType.toString());
+        assertE(returnType.asParameterizedType().arguments().get(0), Ann22.class);
+
+        Type receiver = method.receiverType();
+        assertNotNull(receiver);
+        assertEquals(
+                "org.jboss.jandex.test.@Ann23 TypeToStringWithAnnotationsTest$TestClass<@Ann24 A, @Ann25 B, @Ann26 C>",
+                receiver.toString());
+        assertA(receiver.asParameterizedType().arguments().get(0), Ann24.class);
+        assertB(receiver.asParameterizedType().arguments().get(1), Ann25.class);
+        assertC(receiver.asParameterizedType().arguments().get(2), Ann26.class);
+
+        assertEquals(2, method.parametersCount());
+        assertEquals("@Ann27 E[] @Ann28 []", method.parameterType(0).toString());
+        assertEquals("@Ann27 E @Ann28 []", method.parameterType(0).asArrayType().component().toString());
+        assertE(method.parameterType(0).asArrayType().component().asArrayType().component(), Ann27.class);
+        assertEquals("java.util.@Ann29 List<@Ann30 ? super @Ann31 E>", method.parameterType(1).toString());
+        assertEquals("@Ann30 ? super @Ann31 E", method.parameterType(1).asParameterizedType().arguments().get(0).toString());
+        assertE(method.parameterType(1).asParameterizedType().arguments().get(0).asWildcardType().superBound(), Ann31.class);
+
+        assertEquals(1, method.exceptions().size());
+        assertD(method.exceptions().get(0), Ann32.class);
+
+        ClassInfo inner = index.getClassByName(TestClass.InnerClass.class);
+        assertNotNull(inner);
+        assertEquals(2, inner.typeParameters().size());
+        assertF(inner.typeParameters().get(0), Ann33.class);
+        assertG(inner.typeParameters().get(1), Ann35.class);
+
+        assertEquals(1, inner.interfaceTypes().size());
+        Type innerSuperInterface = inner.interfaceTypes().get(0);
+        assertEquals(
+                "org.jboss.jandex.test.TypeToStringWithAnnotationsTest$TestInterface<@Ann37 G>",
+                innerSuperInterface.toString());
+        assertG(innerSuperInterface.asParameterizedType().arguments().get(0).asTypeVariable(), Ann37.class);
+
+        FieldInfo innerField = inner.field("field");
+        assertNotNull(innerField);
+        assertEquals(
+                "@Ann38 G org.jboss.jandex.test.TypeToStringWithAnnotationsTest$TestClass$InnerClass.field",
+                innerField.toString());
+        assertEquals("@Ann38 G extends @Ann36 F", innerField.type().toString());
+        assertG(innerField.type().asTypeVariable(), Ann38.class);
+    }
+
+    private static void assertA(Type a, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("@" + expectedAnnotation.getSimpleName() + " A extends java.lang.@Ann2 Exception", a.toString());
+    }
+
+    private static void assertB(Type b, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("@" + expectedAnnotation.getSimpleName() + " B extends @Ann4 A", b.toString());
+        assertA(b.asTypeVariable().bounds().get(0), Ann4.class);
+    }
+
+    private static void assertC(Type c, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("@" + expectedAnnotation.getSimpleName() + " C extends @Ann6 B", c.toString());
+        assertB(c.asTypeVariable().bounds().get(0), Ann6.class);
+    }
+
+    private static void assertD(Type d, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("@" + expectedAnnotation.getSimpleName() + " D extends @Ann18 C", d.toString());
+        assertC(d.asTypeVariable().bounds().get(0), Ann18.class);
+    }
+
+    private static void assertE(Type e, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("@" + expectedAnnotation.getSimpleName() + " E extends @Ann20 D", e.toString());
+        assertD(e.asTypeVariable().bounds().get(0), Ann20.class);
+    }
+
+    private static void assertF(Type f, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("@" + expectedAnnotation.getSimpleName() + " F extends @Ann34 C", f.toString());
+        assertC(f.asTypeVariable().bounds().get(0), Ann34.class);
+    }
+
+    private static void assertG(Type g, Class<? extends Annotation> expectedAnnotation) {
+        assertEquals("@" + expectedAnnotation.getSimpleName() + " G extends @Ann36 F", g.toString());
+        assertF(g.asTypeVariable().bounds().get(0), Ann36.class);
+    }
+}


### PR DESCRIPTION
This commit builds on existing support for propagating type annotations
on type parameter bounds. After the existing type annotations on type
parameter bounds propagation pass, a second pass is added that propagates
type annotations on all remaining type variables.

As part of this commit, the string representation of types is improved.
The `Type.toString()` method now has an overload that takes a "simple"
flag. This flag is used to make type variables not append their bounds
into their string representation. With this, the string representation
of declarations and composite types look much closer to the corresponding
Java source code.